### PR TITLE
olap: fix formatter class loading and CASE tuple coercion

### DIFF
--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/cast/CaseTestFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/cast/CaseTestFunDef.java
@@ -44,16 +44,23 @@ class CaseTestFunDef extends AbstractFunctionDefinition {
     @Override
     public Calc<?> compileCall(ResolvedFunCall call, ExpressionCompiler compiler) {
         final Expression[] args = call.getArgs();
+        // When the CASE result type is a (non-boolean) scalar, a value branch that is a tuple/member
+        // must be coerced to its scalar cell value; compile such branches with compileScalar so the
+        // result is the value, not the raw Member[]. (Boolean has its own dedicated calc below.)
+        final boolean scalar = call.getType() instanceof org.eclipse.daanse.olap.api.type.ScalarType
+                && !(call.getType() instanceof BooleanType);
         final BooleanCalc[] conditionCalcs = new BooleanCalc[args.length / 2];
         final Calc<?>[] exprCalcs = new Calc[args.length / 2];
         final List<Calc<?>> calcList = new ArrayList<>();
         for (int i = 0, j = 0; i < exprCalcs.length; i++) {
             conditionCalcs[i] = compiler.compileBoolean(args[j++]);
             calcList.add(conditionCalcs[i]);
-            exprCalcs[i] = compiler.compile(args[j++]);
+            exprCalcs[i] = scalar ? compiler.compileScalar(args[j++], true) : compiler.compile(args[j++]);
             calcList.add(exprCalcs[i]);
         }
-        final Calc<?> defaultCalc = args.length % 2 == 1 ? compiler.compile(args[args.length - 1])
+        final Calc<?> defaultCalc = args.length % 2 == 1
+                ? (scalar ? compiler.compileScalar(args[args.length - 1], true)
+                        : compiler.compile(args[args.length - 1]))
                 : ConstantCalcs.nullCalcOf(call.getType());
         calcList.add(defaultCalc);
         final Calc<?>[] calcs = calcList.stream().toArray(Calc[]::new);

--- a/format/src/main/java/org/eclipse/daanse/olap/format/FormatterFactory.java
+++ b/format/src/main/java/org/eclipse/daanse/olap/format/FormatterFactory.java
@@ -42,6 +42,14 @@ import org.eclipse.daanse.olap.api.formatter.MemberPropertyFormatter;
  *
  * Uses provided context data to instantiate a formatter for the element
  * either by specified class name or script.
+ *
+ * <p><b>TODO (planned):</b> migrate formatter resolution to OSGi Declarative Services. Each formatter
+ * implementation would be published as a {@code @Component} (e.g. with a {@code name} service property),
+ * all of them {@code @Reference}-injected here into a {@code Map<String, CellFormatter/MemberFormatter/…>}
+ * keyed by that name, and a catalog's {@code formatter='…'} would be resolved by a map lookup instead of
+ * reflective {@link Class#forName} loading. That removes the cross-bundle class-visibility problem entirely
+ * (no class loader guessing); the {@code Class.forName} + thread-context-class-loader fallback in
+ * {@link #createFormatter} is the interim bridge until then.
  */
 public class FormatterFactory {
 
@@ -85,7 +93,7 @@ public class FormatterFactory {
             if (context.getFormatterClassName() != null) {
                 return createFormatter(context.getFormatterClassName());
             }
-        } catch (ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             throw new OlapRuntimeException(MessageFormat.format(cellFormatterLoadFailed,
                 context.getFormatterClassName(),
                 context.getElementName(),
@@ -109,7 +117,7 @@ public class FormatterFactory {
             if (context.getFormatterClassName() != null) {
                 return createFormatter(context.getFormatterClassName());
             }
-        } catch (ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             throw new OlapRuntimeException(MessageFormat.format(memberFormatterLoadFailed,
                 context.getFormatterClassName(),
                 context.getElementName(),
@@ -134,7 +142,7 @@ public class FormatterFactory {
             if (context.getFormatterClassName() != null) {
                 return createFormatter(context.getFormatterClassName());
             }
-        } catch (ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             throw new OlapRuntimeException(MessageFormat.format(propertyFormatterLoadFailed,
                 context.getFormatterClassName(),
                 context.getElementName(),
@@ -147,8 +155,25 @@ public class FormatterFactory {
         ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
         InstantiationException, IllegalAccessException {
         @SuppressWarnings("unchecked")
-        Class<T> clazz = (Class<T>) Class.forName(className);
+        Class<T> clazz = (Class<T>) loadFormatterClass(className);
         Constructor<T> constructor = clazz.getConstructor();
         return constructor.newInstance();
+    }
+
+    // Interim, to be replaced by DS-injected formatters looked up by name (see the class javadoc TODO):
+    // reflective class loading cannot reliably see a formatter defined in another bundle under OSGi.
+    private static Class<?> loadFormatterClass(String className) throws ClassNotFoundException {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            // A formatter class named in a catalog can live in a bundle (e.g. a test fragment, or the
+            // application bundle) that this format bundle's class loader cannot see. Fall back to the
+            // thread context class loader before giving up.
+            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+            if (tccl != null) {
+                return Class.forName(className, true, tccl);
+            }
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
- FormatterFactory: fall back to the thread context class loader when the
  bundle class loader cannot see a catalog-defined formatter class; also catch ClassCastException so non-CellFormatter classes yield the intended
  'Failed to load formatter class' error.
- CaseTestFunDef: compile CASE value/default branches with compileScalar so tuple/member branches are coerced to their scalar cell value.
