### PR TITLE
deps: follow jdbc type-model move to jdbc.db.api.type

### DIFF
--- a/api/src/main/java/org/eclipse/daanse/olap/api/element/Level.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/element/Level.java
@@ -30,7 +30,7 @@ package org.eclipse.daanse.olap.api.element;
 
 import java.util.List;
 
-import org.eclipse.daanse.jdbc.db.dialect.api.type.Datatype;
+import org.eclipse.daanse.jdbc.db.api.type.Datatype;
 import org.eclipse.daanse.olap.api.formatter.MemberFormatter;
 import org.eclipse.daanse.olap.api.sql.SqlExpression;
 

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/CSDLUtils.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/CSDLUtils.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.eclipse.daanse.jdbc.db.dialect.api.type.Datatype;
+import org.eclipse.daanse.jdbc.db.api.type.Datatype;
 import org.eclipse.daanse.olap.api.element.Catalog;
 import org.eclipse.daanse.olap.api.element.Cube;
 import org.eclipse.daanse.olap.api.element.Dimension;


### PR DESCRIPTION
Mechanical import rewrite: BestFitColumnType/Datatype moved out of the jdbc.db.dialect.api.type package into the neutral jdbc.db.api.type bundle.
