### PR TITLE
2 Cache fixes

### DIFF
--- a/common/src/main/java/org/eclipse/daanse/olap/access/RoleImpl.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/access/RoleImpl.java
@@ -29,6 +29,7 @@ package org.eclipse.daanse.olap.access;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -1210,13 +1211,24 @@ public class RoleImpl implements Role {
     private static class MemberAccess {
         private final Member member;
         private final AccessMember access;
-        // We use a weak hash map so that it naturally clears
-        // when more memory is required by other parts.
-        // This cache is useful for optimization, but cannot be
-        // let to grow indefinitely. This would cause problems
-        // on high cardinality dimensions.
+        // A bounded cache of "is this granted member a descendant of
+        // parentMember?". The previous WeakHashMap keyed by getUniqueName()
+        // was ineffective: the key strings are freshly built per call and,
+        // with no other strong reference, were GC-eligible almost immediately,
+        // so entries rarely survived to be reused. A size-capped strong map
+        // keeps the cache effective while still bounding growth on
+        // high-cardinality dimensions (the original intent). Insertion order
+        // keeps get() non-mutating.
+        private static final int MAX_PARENTS_CACHED = 1000;
         private final Map<String, Boolean> parentsCache =
-            new WeakHashMap<>();
+            new LinkedHashMap<>(16, 0.75f, false) {
+                @Override
+                protected boolean removeEldestEntry(
+                    Map.Entry<String, Boolean> eldest)
+                {
+                    return size() > MAX_PARENTS_CACHED;
+                }
+            };
         public MemberAccess(
             Member member,
             AccessMember access)

--- a/common/src/main/java/org/eclipse/daanse/olap/fun/sort/TupleExpMemoComparator.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/fun/sort/TupleExpMemoComparator.java
@@ -37,7 +37,6 @@ import java.util.List;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
-import org.eclipse.daanse.olap.api.exception.CellRequestQuantumExceededException;
 import org.eclipse.daanse.olap.common.Util;
 import org.eclipse.daanse.olap.util.CancellationChecker;
 
@@ -54,7 +53,11 @@ import com.github.benmanes.caffeine.cache.Caffeine;
  */
 
 abstract class TupleExpMemoComparator extends TupleComparator.TupleExpComparator {
-  Cache<List<Member>, Object> valueCache = Caffeine.newBuilder().maximumSize( 100000 ).build();
+  // Lazily created on first eval() so subclasses that never memoize
+  // (HierarchicalTupleComparator evaluates directly) don't allocate an unused
+  // cache. A comparator is used by a single sort on one thread, so no
+  // synchronization is needed.
+  private Cache<List<Member>, Object> valueCache;
 
   private int[] dependentHierarchiesIndices;
   private int count = 0;
@@ -65,19 +68,13 @@ abstract class TupleExpMemoComparator extends TupleComparator.TupleExpComparator
 
   // applies the Calc to a tuple, memorizing results
   protected Object eval( List<Member> key ) {
-    try {
-      return valueCache.get( key, this::evaluateCalc );
-    } catch ( Exception e ) {
-      if ( e.getCause() instanceof CellRequestQuantumExceededException ) {
-        // this exception can occur if evaluation required greater than
-        // mondrian.result.limit batched cells.  Throwing the exception
-        // results in currently batched cells being loaded, followed by
-        // another iteration.
-        // the guava Cache wraps the exception, but we want this one to percolate up.
-        throw CellRequestQuantumExceededException.INSTANCE;
-      }
-      throw e;
+    if ( valueCache == null ) {
+      valueCache = Caffeine.newBuilder().maximumSize( 100000 ).build();
     }
+    // Loader exceptions (e.g. CellRequestQuantumExceededException, which drives
+    // the batch-reload protocol) propagate unwrapped: Caffeine does not wrap
+    // them, unlike the former Guava cache.
+    return valueCache.get( key, this::evaluateCalc );
   }
 
   private List<Member> dependentMembers( List<Member> tuple ) {


### PR DESCRIPTION
fix: bound RoleImpl.parentsCache and make it effective
parentsCache was a WeakHashMap keyed by parentMember.getUniqueName(). Those
key strings are built fresh per call and, with no other strong reference,
became GC-eligible almost immediately, so entries rarely survived to be
reused — the cache was effectively a no-op. Replace it with a size-capped
LinkedHashMap (insertion order, so get() stays non-mutating), which keeps
the cache effective while still bounding growth on high-cardinality
dimensions, exactly the intent stated in the original code comment.

refactor: drop dead exception handling and lazy-allocate the memo cache
TupleExpMemoComparator.eval() wrapped the cache load in a try/catch that
checked e.getCause() for CellRequestQuantumExceededException and rethrew
the INSTANCE. That check was dead: it dates from the Guava cache which
wrapped loader exceptions, but Caffeine propagates them unwrapped, so the
branch was unreachable and only the plain rethrow ever ran. Remove it (and
the stale "guava Cache wraps" comment); the exception simply propagates.

Also lazy-allocate valueCache on first eval(), so HierarchicalTupleComparator
— which evaluates directly and never calls eval() — no longer allocates an
unused 100000-entry cache per instance.