### PR TITLE
refactor!: null semantics without in-band sentinels

### DIFF
--- a/api/src/main/java/org/eclipse/daanse/olap/api/result/Cell.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/result/Cell.java
@@ -48,28 +48,28 @@ public interface Cell {
      * Returns the coordinates of this Cell in its Result.
      *
      * @return Coordinates of this Cell
-     */
+ */
     List<Integer> getCoordinateList();
 
     /**
      * Returns the cell's raw value. This is useful for sending to further data
      * processing, such as plotting a chart.
      *
-     * The value is never null. It may have various types: if the cell is null, the
-     * value is Util#nullValue; if the cell contains an error, the value is an
-     * instance of Throwable; otherwise, the type of this value depends upon the
-     * type of measure: possible types include java.math.BigDecimal, Double, Integer
-     * and String.
+     * <p>
+     * If the cell is NULL, the value is Java {@code null}. If the
+     * cell contains an error, {@link #isError()} is true and this method
+     * returns the underlying {@link Throwable}. Otherwise the type of this value
+     * depends upon the type of measure: possible types include
+     * java.math.BigDecimal, Double, Integer and String.
      *
-     *
-     * return != null (return instanceof Throwable) == isError() (return instanceof
-     * Util.NullCellValue) == isNull()
-     */
+     * <p>
+     * {@code (return == null) == isNull()}
+ */
     Object getValue();
 
     /**
      * Return the cached formatted string, that survives an aggregate cache clear.
-     */
+ */
     String getCachedFormatString();
 
     /**
@@ -77,17 +77,17 @@ public interface Cell {
      * and locale-specific settings such as currency symbol. The current format
      * string may itself be derived via an expression. For more information about
      * format strings, see mondrian.util.Format.
-     */
+ */
     String getFormattedValue();
 
     /**
      * Returns whether the cell's value is null.
-     */
+ */
     boolean isNull();
 
     /**
      * Returns whether the cell's calculation returned an error.
-     */
+ */
     boolean isError();
 
     /**
@@ -102,7 +102,7 @@ public interface Cell {
      * levels (coulmns) of non-constraining members.
      *
      * The result is null if the cell is based upon a calculated member.
-     */
+ */
     String getDrillThroughSQL(boolean extendedContext);
 
     /**
@@ -110,12 +110,12 @@ public interface Cell {
      * Cell is based on a calculated measure.
      *
      * @return Whether can drill through on this cell
-     */
+ */
     boolean canDrillThrough();
 
     /**
      * Returns the number of fact table rows which contributed to this Cell.
-     */
+ */
     int getDrillThroughCount();
 
     /**
@@ -123,7 +123,7 @@ public interface Cell {
      *
      * @param propertyName Case-sensitive property name
      * @return Value of property
-     */
+ */
     Object getPropertyValue(String propertyName);
 
     /**
@@ -142,7 +142,7 @@ public interface Cell {
      *
      * @param hierarchy Hierarchy
      * @return current member of given hierarchy
-     */
+ */
     Member getContextMember(Hierarchy hierarchy);
 
     /**
@@ -152,7 +152,7 @@ public interface Cell {
      * @param newValue         New value
      * @param allocationPolicy Allocation policy
      * @param allocationArgs   Arguments for allocation policy
-     */
+ */
     void setValue(Scenario scenario, Object newValue, AllocationPolicy allocationPolicy, Object... allocationArgs);
 
     SqlStatementI drillThroughInternal(int maxRowCount, int firstRowOrdinal, List<OlapElement> fields,

--- a/api/src/main/java/org/eclipse/daanse/olap/api/result/CellValue.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/result/CellValue.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.api.result;
+
+/**
+ * The state of a cell at the cell/cache boundary.
+ *
+ * <p>
+ * Between segment storage and the public {@link Cell} API a cell is in
+ * exactly one of four states. This sealed hierarchy makes the protocol
+ * explicit and compiler-checked: an exhaustive {@code switch} over
+ * {@code CellValue} cannot silently forget a state.
+ *
+ * <ul>
+ * <li>{@link NullValue} — the cell evaluates to MDX NULL,</li>
+ * <li>{@link NotLoaded} — the cell is not in the cache yet (batching
+ * pass),</li>
+ * <li>{@link ErrorValue} — evaluation failed; carries the cause,</li>
+ * <li>{@link ObjectValue} — a real value (the already-boxed value
+ * object).</li>
+ * </ul>
+ *
+ * <p>
+ * Deliberately no {@code NumericValue(double)} variant: that would allocate
+ * per cell in the aggregation hot path (revisit with Valhalla value classes).
+ */
+public sealed interface CellValue permits NullValue, NotLoaded, ErrorValue, ObjectValue {
+
+    /**
+     * Unwraps to the legacy object convention of the public {@link Cell} API:
+     * {@link NullValue} → Java {@code null}, {@link ErrorValue} → the
+     * {@link Throwable}, {@link ObjectValue} → the value,
+     * {@link NotLoaded} → the marker itself.
+ */
+    default Object toLegacyValue() {
+        return switch (this) {
+        case NullValue v -> null;
+        case NotLoaded n -> n;
+        case ErrorValue e -> e.cause();
+        case ObjectValue o -> o.value();
+        };
+    }
+
+    /**
+     * Wraps a value in the legacy object convention: Java {@code null} →
+     * {@link NullValue}, {@link NotLoaded} → itself, a {@link Throwable} →
+     * {@link ErrorValue}, an existing {@code CellValue} → itself, anything
+     * else → {@link ObjectValue}.
+ */
+    static CellValue fromLegacyValue(Object o) {
+        if (o == null) {
+            return NullValue.INSTANCE;
+        }
+        if (o instanceof CellValue cv) {
+            return cv;
+        }
+        if (o instanceof Throwable t) {
+            return new ErrorValue(t);
+        }
+        return new ObjectValue(o);
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/result/ErrorValue.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/result/ErrorValue.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.api.result;
+
+import java.util.Objects;
+
+/**
+ * Evaluation of the cell failed. Replaces the historical
+ * Throwable-stored-as-cell-value idiom, see {@link CellValue}.
+ */
+public record ErrorValue(Throwable cause) implements CellValue {
+
+    public ErrorValue {
+        Objects.requireNonNull(cause, "cause");
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/result/NotLoaded.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/result/NotLoaded.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.api.result;
+
+/**
+ * Marker for a cell whose value has not been loaded from the database yet.
+ *
+ * <p>
+ * The batching cell reader returns this singleton on a cache miss while it
+ * collects cell requests; the evaluation pass that produced it is marked
+ * dirty and its results are discarded after the batch has been fetched.
+ * {@code NotLoaded} is
+ * deliberately not a {@link Number}: any code that tries to compute with it
+ * fails fast instead of silently producing values from thin air.
+ */
+public record NotLoaded() implements CellValue {
+
+    public static final NotLoaded INSTANCE = new NotLoaded();
+
+    @Override
+    public String toString() {
+        return "NOT_LOADED";
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/result/NullValue.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/result/NullValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.api.result;
+
+/**
+ * The cell evaluates to MDX NULL. Allocation-free singleton, see
+ * {@link CellValue}.
+ */
+public record NullValue() implements CellValue {
+
+    public static final NullValue INSTANCE = new NullValue();
+
+    @Override
+    public String toString() {
+        return "NULL";
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/result/ObjectValue.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/result/ObjectValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.api.result;
+
+import java.util.Objects;
+
+/**
+ * A real cell value, carrying the already-boxed value object (often a
+ * {@link Double}, {@link java.math.BigDecimal}, {@link Integer} or
+ * {@link String}), see {@link CellValue}.
+ */
+public record ObjectValue(Object value) implements CellValue {
+
+    public ObjectValue {
+        Objects.requireNonNull(value, "value; use NullValue.INSTANCE for MDX NULL");
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/CompensatedSum.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/CompensatedSum.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.calc.base;
+
+/**
+ * Compensated (Neumaier/Kahan-Babuška) summation accumulator.
+ *
+ * <p>
+ * Plain left-to-right {@code double} summation loses low-order bits whenever
+ * addends differ in magnitude; over large aggregations the error grows with
+ * O(n). Neumaier's variant tracks the running rounding error in a
+ * compensation term and folds it into the result, reducing the error to the
+ * order of one ulp independent of n — including the case where the addend is
+ * larger in magnitude than the running sum (which classic Kahan mishandles).
+ *
+ * <p> * Used by the double-lane aggregates
+ * ({@code FunUtil.sumDouble}/{@code avg}/{@code var}, rolap
+ * {@code SumAggregator}).
+ * Not thread-safe; one instance per aggregation loop.
+ */
+public final class CompensatedSum {
+
+    private double sum;
+    private double compensation;
+
+    public void add(double value) {
+        double t = sum + value;
+        if (Math.abs(sum) >= Math.abs(value)) {
+            compensation += (sum - t) + value;
+        } else {
+            compensation += (value - t) + sum;
+        }
+        sum = t;
+    }
+
+    /** The compensated total. */
+    public double value() {
+        return sum + compensation;
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/NullSemantics.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/NullSemantics.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.calc.base;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import org.eclipse.daanse.olap.api.result.NotLoaded;
+import org.eclipse.daanse.olap.common.Util;
+import org.eclipse.daanse.olap.fun.sort.OrderKey;
+
+/**
+ * Single home of the MDX NULL semantics of the calculation layer: the NULL
+ * checks and the MSAS-compatible value ordering.
+ *
+ * <p>
+ * MDX NULL is represented as Java {@code null} throughout the calc and cell
+ * layers. The comparison methods define the total order used by sorts and
+ * rank functions: {@code -Inf < values < NaN < +Inf} for numbers, with NULL
+ * (and the not-yet-loaded marker of the dirty evaluation pass) sorting below
+ * everything at the object level.
+ */
+public final class NullSemantics {
+
+    private NullSemantics() {
+        // utility class
+    }
+
+    /**
+     * Boxed NULL check: MDX NULL in the {@code Double} calc world is Java
+     * {@code null}.
+     */
+    public static boolean isNull(Double v) {
+        return v == null;
+    }
+
+    /**
+     * Object-level NULL check: MDX NULL at the cell/object level is Java
+     * {@code null}.
+     */
+    public static boolean isNull(Object o) {
+        return o == null;
+    }
+
+    /**
+     * Compares two unboxed cell values forming the total order
+     * {@code -Inf < values < NaN < +Inf} (MSAS-compatible NaN placement).
+     *
+     * <p>
+     * A primitive {@code double} cannot carry MDX NULL (NULL is Java
+     * {@code null} at the boxed level, handled by
+     * {@link #compareCellValues(Object, Object)}), so this order has no NULL
+     * slot.
+     */
+    public static int compare(double d1, double d2) {
+        if (Double.isNaN(d1)) {
+            if (d2 == Double.POSITIVE_INFINITY) {
+                return -1;
+            } else if (Double.isNaN(d2)) {
+                return 0;
+            } else {
+                return 1;
+            }
+        } else if (Double.isNaN(d2)) {
+            if (d1 == Double.POSITIVE_INFINITY) {
+                return 1;
+            } else {
+                return -1;
+            }
+        } else if (d1 == d2) {
+            return 0;
+        } else if (d1 < d2) {
+            return -1;
+        } else {
+            return 1;
+        }
+    }
+
+    /**
+     * Compares two boxed/object cell values: Java {@code null} (MDX NULL)
+     * sorts below everything including {@code -Infinity}, the
+     * {@link NotLoaded} marker of the dirty evaluation pass next, then typed
+     * values are compared — Strings case-insensitively, Numbers by the
+     * unboxed order of {@link #compare(double, double)}, dates and
+     * {@link OrderKey}s naturally.
+     */
+    public static int compareCellValues(Object value0, Object value1) {
+        if (value0 == value1) {
+            return 0;
+        }
+        // null is less than anything else
+        if (value0 == null) {
+            return -1;
+        }
+        if (value1 == null) {
+            return 1;
+        }
+
+        if (value0 == NotLoaded.INSTANCE) {
+            // the left value is not in cache; continue as best as we can
+            return -1;
+        } else if (value1 == NotLoaded.INSTANCE) {
+            // the right value is not in cache; continue as best as we can
+            return 1;
+        } else if (value0 instanceof String str) {
+            return str.compareToIgnoreCase((String) value1);
+        } else if (value0 instanceof Number numberValue0) {
+            return compare(numberValue0.doubleValue(), ((Number) value1).doubleValue());
+        } else if (value0 instanceof Date date) {
+            return date.compareTo((Date) value1);
+        } else if (value0 instanceof LocalDateTime localDateTime) {
+            return localDateTime.compareTo((LocalDateTime) value1);
+        } else if (value0 instanceof OrderKey orderKey && value1 instanceof OrderKey orderKeyOther) {
+            return orderKey.compareTo(orderKeyOther);
+        } else {
+            throw Util.newInternal("cannot compare " + value0);
+        }
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/compiler/BaseExpressionCompiler.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/compiler/BaseExpressionCompiler.java
@@ -108,7 +108,7 @@ public class BaseExpressionCompiler implements ExpressionCompiler {
      *
      * @param evaluator Evaluator
      * @param validator Validator
-     */
+ */
     public BaseExpressionCompiler(Evaluator evaluator, Validator validator) {
         this(evaluator, validator, ResultStyle.ANY_LIST);
     }
@@ -120,7 +120,7 @@ public class BaseExpressionCompiler implements ExpressionCompiler {
      * @param evaluator    Evaluator
      * @param validator    Validator
      * @param resultStyles List of result styles, preferred first, must not be
-     */
+ */
     public BaseExpressionCompiler(Evaluator evaluator, Validator validator, List<ResultStyle> resultStyles) {
         this.evaluator = evaluator;
         this.validator = validator;
@@ -358,6 +358,9 @@ public class BaseExpressionCompiler implements ExpressionCompiler {
         }
         if (calc instanceof ConstantCalc constantCalc) {
             Boolean bool = switch (constantCalc.evaluate(null)) {
+            // Deliberately NOT null: booleans stay two-valued (no 3VL), so a
+            // NULL constant folds to BOOLEAN_NULL == false - null-to-false is
+            // behavior, not sentinel encoding.
             case null -> FunUtil.BOOLEAN_NULL;
             case Boolean b -> b;
             case Number n -> n.intValue() > 0;
@@ -379,7 +382,8 @@ public class BaseExpressionCompiler implements ExpressionCompiler {
             Object evaluated = constantCalc.evaluate(null);
             if (!(evaluated instanceof Double)) {
                 Double doub = switch (evaluated) {
-                    case null -> FunUtil.DOUBLE_NULL;
+                    // MDX NULL is Java null in the Double calc world.
+                    case null -> null;
                     case Double d -> d;
                     case Number n -> n.doubleValue();
                     case Object obj -> throw TypeConversionException.cannotConvert(obj, "Double");

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/booleanx/DoubleToBooleanCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/booleanx/DoubleToBooleanCalc.java
@@ -16,6 +16,7 @@ package org.eclipse.daanse.olap.calc.base.type.booleanx;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedBooleanCalc;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
@@ -29,7 +30,9 @@ public class DoubleToBooleanCalc extends AbstractProfilingNestedBooleanCalc {
 	public Boolean evaluateInternal(Evaluator evaluator) {
 		Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
 
-		if (Double.isNaN(v0) || v0 == FunUtil.DOUBLE_NULL) {
+		// Null check must come first: MDX NULL is Java null and
+		// Double.isNaN would throw on unboxing.
+		if (NullSemantics.isNull(v0) || Double.isNaN(v0)) {
 			return FunUtil.BOOLEAN_NULL;
 		}
 

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/booleanx/UnknownToBooleanCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/booleanx/UnknownToBooleanCalc.java
@@ -13,6 +13,7 @@
 */
 package org.eclipse.daanse.olap.calc.base.type.booleanx;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.type.Type;
@@ -30,6 +31,10 @@ public class UnknownToBooleanCalc extends AbstractProfilingNestedBooleanCalc {
 		Object v0 = getFirstChildCalc().evaluate(evaluator);
 		if (v0 == null) {
 			return FunUtil.BOOLEAN_NULL;
+		}
+		if (v0 == NotLoaded.INSTANCE) {
+			// dirty pass, results discarded; dummy matches the old Double(0) marker
+			return false;
 		}
 		if (v0 instanceof Boolean b) {
 			return b;

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/doublex/IntegerToDoubleCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/doublex/IntegerToDoubleCalc.java
@@ -17,7 +17,6 @@ import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.IntegerCalc;
 import org.eclipse.daanse.olap.api.type.Type;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class IntegerToDoubleCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -30,9 +29,7 @@ public class IntegerToDoubleCalc extends AbstractProfilingNestedDoubleCalc {
 
 		Integer i = getChildCalc(0, IntegerCalc.class).evaluate(evaluator);
 		if (i == null) {
-			return FunUtil.DOUBLE_NULL;
-			// null;
-			// TODO: !!! JUST REFACTORING 0 must be null
+			return null;
 		}
 		return i.doubleValue();
 	}

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/doublex/UnknownToDoubleCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/doublex/UnknownToDoubleCalc.java
@@ -13,13 +13,12 @@
 */
 package org.eclipse.daanse.olap.calc.base.type.doublex;
 
-import java.util.Objects;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.type.Type;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class UnknownToDoubleCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -32,11 +31,12 @@ public class UnknownToDoubleCalc extends AbstractProfilingNestedDoubleCalc {
 
 		Object o = getFirstChildCalc().evaluate(evaluator);
 		if (o == null) {
-			return FunUtil.DOUBLE_NULL;
-			// null;
-			// TODO: !!! JUST REFACTORING 0 must be null
-		} else if (Objects.equals(o, FunUtil.DOUBLE_NULL)) {
-			return FunUtil.DOUBLE_NULL;
+			return null;
+		} else if (o == NotLoaded.INSTANCE) {
+			// Dirty evaluation pass: the cell is not loaded yet and this
+			// pass's results are discarded. Substitute the same dummy the
+			// old Double(0) marker used to inject, but keep the lie local.
+			return 0.0;
 		} else if (o instanceof Double d) {
 			return d;
 		} else if (o instanceof Number n) {

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/integer/UnknownToIntegerCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/type/integer/UnknownToIntegerCalc.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.daanse.olap.calc.base.type.integer;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.type.Type;
@@ -30,6 +31,9 @@ public class UnknownToIntegerCalc extends AbstractProfilingNestedIntegerCalc {
 		Object o = getFirstChildCalc().evaluate(evaluator);
 		if (o == null) {
 			return null;
+		} else if (o == NotLoaded.INSTANCE) {
+			// dirty pass, results discarded; dummy matches the old Double(0) marker
+			return 0;
 		} else if (o instanceof Number n) {
 			return n.intValue();
 		}

--- a/common/src/main/java/org/eclipse/daanse/olap/calc/base/value/CurrentValueDoubleCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/calc/base/value/CurrentValueDoubleCalc.java
@@ -15,7 +15,6 @@ package org.eclipse.daanse.olap.calc.base.value;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
 import org.eclipse.daanse.olap.calc.base.AbstractProfilingValueCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class CurrentValueDoubleCalc extends AbstractProfilingValueCalc<Double> implements DoubleCalc{
 
@@ -27,7 +26,7 @@ public class CurrentValueDoubleCalc extends AbstractProfilingValueCalc<Double> i
 	@Override
 	protected Double convertCurrentValue(Object evaluatedCurrentValue) {
 		if (evaluatedCurrentValue == null) {
-			return FunUtil.DOUBLE_NULL;
+			return null;
 		} else if (evaluatedCurrentValue instanceof Double d) {
 			return d;
 		} else if (evaluatedCurrentValue instanceof Number n) {

--- a/common/src/main/java/org/eclipse/daanse/olap/common/Util.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/common/Util.java
@@ -28,7 +28,6 @@
  */
 package org.eclipse.daanse.olap.common;
 
-import static org.eclipse.daanse.olap.fun.FunUtil.DOUBLE_EMPTY;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -90,7 +89,6 @@ import org.eclipse.daanse.olap.api.Parameter;
 import org.eclipse.daanse.olap.api.access.Role;
 import org.eclipse.daanse.olap.api.agg.Segment;
 import org.eclipse.daanse.olap.api.calc.Calc;
-import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.calc.profile.CalculationProfile;
 import org.eclipse.daanse.olap.api.calc.profile.ProfileHandler;
 import org.eclipse.daanse.olap.api.catalog.CatalogReader;
@@ -173,36 +171,15 @@ public class Util {
             LoggerFactory.getLogger("daanse.profile");
 
     /**
-     * Special value which indicates that a {@code double} computation has returned the MDX null value. See {@link
-     * DoubleCalc}.
-     */
-    public static final Double DOUBLE_NULL = Double.valueOf(0.000000012345);
-
-    /**
-     * Placeholder which indicates a value NULL.
-     */
-    public static final Object nullValue = DOUBLE_NULL;
-
-    /**
-     * Special cell value indicates that the value is not in cache yet.
-     */
-    public static final Object valueNotReadyException = Double.valueOf(0);
-
-    /**
-     * Placeholder which indicates an EMPTY value.
-     */
-    public static final Object EmptyValue = Double.valueOf(DOUBLE_EMPTY);
-
-    /**
      * Special value represents a null key.
-     */
+ */
     public static final Comparable<?> sqlNullValue =
         Util.UtilComparable.INSTANCE;
 
     /**
      * A comparator singleton instance which can handle the presence of
      * RolapUtilComparable instances in a collection.
-     */
+ */
     public static final Comparator OLAP_COMPARATOR =
         new UtilComparator();
 
@@ -220,10 +197,14 @@ public class Util {
                 throw new OlapRuntimeException(cce);
             }
         }
-    } 
-    
+    }
+
+    /**
+     * Returns whether a cell value corresponds to the MDX NULL value, which
+     * is Java {@code null}.
+ */
     public static boolean isNull(Object o) {
-        return o == null || o == nullValue;
+        return o == null;
     }
 
     /**
@@ -231,7 +212,7 @@ public class Util {
      *
      * @param value The source string to parse.
      * @return A checksum of the source string.
-     */
+ */
     public static byte[] digestSha256(String value) {
         final MessageDigest algorithm;
         try {
@@ -247,7 +228,7 @@ public class Util {
      *
      * @param value String to create one way hash upon.
      * @return SHA-512 hash.
-     */
+ */
     public static byte[] digestSHA(final String value) {
         final MessageDigest algorithm;
         try {
@@ -270,7 +251,7 @@ public class Util {
      * @param name The name of the threads.
      * @param rejectionPolicy The rejection policy to enforce.
      * @return An executor service preconfigured.
-     */
+ */
     public static ExecutorService getExecutorService(
         int maximumPoolSize,
         int corePoolSize,
@@ -330,7 +311,7 @@ public class Util {
      * threads.
      * @param name The name of the threads.
      * @return An scheduled executor service preconfigured.
-     */
+ */
     public static ScheduledExecutorService getScheduledExecutorService(
         final int maxNbThreads,
         final String name)
@@ -353,7 +334,7 @@ public class Util {
 
     /**
      * Converts a string into a double-quoted string.
-     */
+ */
     public static String quoteForMdx(String val) {
         StringBuilder buf = new StringBuilder(val.length() + 20);
         quoteForMdx(buf, val);
@@ -362,7 +343,7 @@ public class Util {
 
     /**
      * Appends a double-quoted string to a string builder.
-     */
+ */
     public static StringBuilder quoteForMdx(StringBuilder buf, String val) {
         buf.append("\"");
         String s0 = val.replace("\"", "\"\"");
@@ -375,7 +356,7 @@ public class Util {
      * Return string quoted in [...].  For example, "San Francisco" becomes
      * "[San Francisco]"; "a [bracketed] string" becomes
      * "[a [bracketed]] string]".
-     */
+ */
     public static String quoteMdxIdentifier(String id) {
     	if (id != null) {
     		StringBuilder buf = new StringBuilder(id.length() + 20);
@@ -394,7 +375,7 @@ public class Util {
     /**
      * Return identifiers quoted in [...].[...].  For example, {"Store", "USA",
      * "California"} becomes "[Store].[USA].[California]".
-     */
+ */
     public static String quoteMdxIdentifier(List<Segment> ids) {
         StringBuilder sb = new StringBuilder(64);
         quoteMdxIdentifier(ids, sb);
@@ -418,7 +399,7 @@ public class Util {
      *
      * @param s Unquoted literal
      * @return Quoted string literal
-     */
+ */
     @SuppressWarnings("java:S5361") // need use replaceAll
     public static String quoteJavaString(String s) {
         return s == null
@@ -434,7 +415,7 @@ public class Util {
      * Takes into account the
      * {@link SystemWideProperties#CaseSensitive case sensitive option}.
      * Names may be null.
-     */
+ */
     public static boolean equalName(String s, String t) {
         if (s == null) {
             return t == null;
@@ -451,7 +432,7 @@ public class Util {
      * @param t Second string
      * @param matchCase Whether to perform case-sensitive match
      * @return Whether strings are equal
-     */
+ */
     public static boolean equalWithMatchCaseOption(String s, String t, boolean matchCase) {
         if (s == null) {
             return t == null;
@@ -465,7 +446,7 @@ public class Util {
      * Takes into account the {@link SystemWideProperties#CaseSensitive case
      * sensitive option}.
      * Names must not be null.
-     */
+ */
     public static int caseSensitiveCompareName(String s, String t) {
         boolean caseSensitive =
             SystemWideProperties.instance().CaseSensitive;
@@ -485,7 +466,7 @@ public class Util {
      * Takes into account the {@link SystemWideProperties#CaseSensitive case
      * sensitive option}.
      * Names must not be null.
-     */
+ */
     public static int compareName(String s, String t) {
         boolean caseSensitive =
             SystemWideProperties.instance().CaseSensitive;
@@ -497,7 +478,7 @@ public class Util {
      * Returns the upper case name if
      * {@link SystemWideProperties#CaseSensitive} is true, the name unchanged
      * otherwise.
-     */
+ */
     public static String normalizeName(String s) {
         return SystemWideProperties.instance().CaseSensitive
             ? s
@@ -508,7 +489,7 @@ public class Util {
      * Returns the result of ((Comparable) k1).compareTo(k2), with
      *
      * @see Comparable#compareTo
-     */
+ */
     public static int compareKey(Object k1, Object k2) {
         return ((Comparable) k1).compareTo(k2);
     }
@@ -519,7 +500,7 @@ public class Util {
      *
      * @param s MDX identifier
      * @return List of segments
-     */
+ */
     public static List<Segment> parseIdentifier(String s)  {
         return convert(
             IdentifierParser.parseIdentifier(s));
@@ -528,7 +509,7 @@ public class Util {
     /**
      * Converts an array of name parts {"part1", "part2"} into a single string
      * "[part1].[part2]". If the names contain "]" they are escaped as "]]".
-     */
+ */
     public static String implode(List<Segment> names) {
         StringBuilder sb = new StringBuilder(64);
         for (int i = 0; i < names.size(); i++) {
@@ -605,7 +586,7 @@ public class Util {
      * !(failIfNotFound and return == null)
      *
      * @see #parseIdentifier(String)
-     */
+ */
     public static OlapElement lookupCompound(
         CatalogReader catalogReader,
         OlapElement parent,
@@ -807,7 +788,7 @@ public class Util {
      * @param nameParts Parts of the identifier
      * @param allowProp Whether to allow property references
      * @return OLAP object or property reference
-     */
+ */
     public static Expression lookup(
         Query q,
         List<Segment> nameParts,
@@ -831,7 +812,7 @@ public class Util {
      * @param segments Parts of the identifier
      * @param allowProp Whether to allow property references
      * @return OLAP object or property reference
-     */
+ */
     public static Expression lookup(
         Query q,
         CatalogReader catalogReader,
@@ -930,7 +911,7 @@ public class Util {
      * @param cubeName Cube name
      * @param fail Whether to fail if not found.
      * @return Cube, or null if not found
-     */
+ */
     public static Cube lookupCube(
         CatalogReader schemaReader,
         String cubeName,
@@ -950,7 +931,7 @@ public class Util {
     /**
      * Converts an olap element (dimension, hierarchy, level or member) into
      * an expression representing a usage of that element in an MDX statement.
-     */
+ */
     public static Expression createExpr(OlapElement element)
     {
         if (element instanceof Member member) {
@@ -976,7 +957,7 @@ public class Util {
      * @param hierarchy Hierarchy
      * @param memberName Name of root member
      * @return Member, or null if not found
-     */
+ */
     public static Member lookupHierarchyRootMember(
         CatalogReader reader,
         Hierarchy hierarchy,
@@ -1064,7 +1045,7 @@ public class Util {
     /**
      * Finds a named level in this hierarchy. Returns null if there is no
      * such level.
-     */
+ */
     public static Level lookupHierarchyLevel(Hierarchy hierarchy, String s) {
         final List<? extends Level> levels = hierarchy.getLevels();
         for (Level level : levels) {
@@ -1079,7 +1060,7 @@ public class Util {
 
     /**
      * Finds the zero based ordinal of a Member among its siblings.
-     */
+ */
     public static int getMemberOrdinalInParent(
         CatalogReader reader,
         Member member)
@@ -1103,7 +1084,7 @@ public class Util {
      * returns the first descendant on the level underneath parent.
      * If parent = [Time].[1997] and level = [Time].[Month], then
      * the member [Time].[1997].[Q1].[1] will be returned
-     */
+ */
     public static Member getFirstDescendantOnLevel(
         CatalogReader reader,
         Member parent,
@@ -1119,7 +1100,7 @@ public class Util {
 
     /**
      * Returns whether a string is null or empty.
-     */
+ */
     public static boolean isEmpty(String s) {
         return (s == null) || (s.isEmpty());
     }
@@ -1128,7 +1109,7 @@ public class Util {
      * Encloses a value in single-quotes, to make a SQL string value. Examples:
      * singleQuoteForSql(null) yields NULL;
      * singleQuoteForSql("don't") yields 'don''t'.
-     */
+ */
     public static String singleQuoteString(String val) {
         StringBuilder buf = new StringBuilder(64);
         singleQuoteString(val, buf);
@@ -1139,7 +1120,7 @@ public class Util {
      * Encloses a value in single-quotes, to make a SQL string value. Examples:
      * singleQuoteForSql(null) yields NULL;
      * singleQuoteForSql("don't") yields 'don''t'.
-     */
+ */
     public static void singleQuoteString(String val, StringBuilder buf) {
         buf.append('\'');
 
@@ -1159,7 +1140,7 @@ public class Util {
      * @param propertyName Property name
      * @param level Level
      * @return Whether property is valid
-     */
+ */
     public static boolean isValidProperty(
         String propertyName,
         Level level)
@@ -1170,7 +1151,7 @@ public class Util {
     /**
      * Finds a member property called propertyName at, or above,
      * level.
-     */
+ */
     public static Property lookupProperty(
         Level level,
         String propertyName)
@@ -1223,7 +1204,7 @@ public class Util {
     /**
      * Returns an exception which indicates that a particular piece of
      * functionality should work, but a developer has not implemented it yet.
-     */
+ */
     public static RuntimeException needToImplement(Object o) {
         throw new UnsupportedOperationException("need to implement " + o);
     }
@@ -1231,7 +1212,7 @@ public class Util {
     /**
      * Returns an exception indicating that we didn't expect to find this value
      * here.
-     */
+ */
     public static <T extends Enum<T>> RuntimeException badValue(
         Enum<T> anEnum)
     {
@@ -1248,7 +1229,7 @@ public class Util {
      * If errors are encountered while canceling a statement,
      * the message is logged in {@link Util}.
      * @param stmt The statement to cancel.
-     */
+ */
     public static void cancelStatement(Statement stmt) {
         try {
             // A call to statement.isClosed() would be great here, but in
@@ -1289,7 +1270,7 @@ public class Util {
      * @param s Prefix
      * @param list List
      * @return String representation of string
-     */
+ */
     public static <T> String commaList(
         String s,
         List<T> list)
@@ -1311,7 +1292,7 @@ public class Util {
      *
      * @param collection Collection
      * @return boolean true if all values are same
-     */
+ */
     public static <T> boolean areOccurencesEqual(
         Collection<T> collection)
     {
@@ -1338,7 +1319,7 @@ public class Util {
      *
      * @param localeString Locale string, e.g. "en" or "en_US"
      * @return Java locale object
-     */
+ */
     public static Locale parseLocale(String localeString) {
         String[] strings = localeString.split("_");
         switch (strings.length) {
@@ -1360,7 +1341,7 @@ public class Util {
      *
      * @param olap4jSegmentList List of olap4j segments
      * @return List of mondrian segments
-     */
+ */
     public static List<Segment> convert(
         List<IdentifierSegment> olap4jSegmentList)
     {
@@ -1372,7 +1353,7 @@ public class Util {
      *
      * @param olap4jSegment olap4j segment
      * @return mondrian segment
-     */
+ */
     public static Segment convert(IdentifierSegment olap4jSegment) {
         if (olap4jSegment instanceof NameIdentifierSegment nameSegment) {
             return convertNS(nameSegment);
@@ -1525,7 +1506,7 @@ public class Util {
      * @param message Message to qualify wrapped exception
      * @param <T> Result type
      * @return Result
-     */
+ */
     public static <T> T safeGet(Future<T> future, String message) {
         try {
             return future.get();
@@ -1548,7 +1529,7 @@ public class Util {
     /**
      * As Arrays#binarySearch(Object[], int, int, Object), but
      * available pre-JDK 1.6.
-     */
+ */
     public static <T extends Comparable<T>> int binarySearch(
         T[] ts, int start, int end, T t)
     {
@@ -1565,7 +1546,7 @@ public class Util {
      * @param set1 First set
      * @param set2 Second set
      * @return Intersection of the sets
-     */
+ */
     public static <E extends Comparable> SortedSet<E> intersect(
         SortedSet<E> set1,
         SortedSet<E> set2)
@@ -1622,7 +1603,7 @@ public class Util {
      * @param <T> Element type
      * @return Last item in the list
      * @throws IndexOutOfBoundsException if list is empty
-     */
+ */
     public static <T> T last(List<T> list) {
         return list.get(list.size() - 1);
     }
@@ -1638,7 +1619,7 @@ public class Util {
      * @param resultSet Result set
      * @param statement Statement
      * @param connection Connection
-     */
+ */
     public static SQLException close(
         ResultSet resultSet,
         Statement statement,
@@ -1726,7 +1707,7 @@ public class Util {
      * @param fromIndex Index of the first bit to be set.
      * @param toIndex   Index after the last bit to be set.
      * @return Bit set
-     */
+ */
     public static BitSet bitSetBetween(int fromIndex, int toIndex) {
         final BitSet bitSet = new BitSet();
         if (toIndex > fromIndex) {
@@ -1746,7 +1727,7 @@ public class Util {
     /**
      * Throws an internal error if condition is not true. It would be called
      * assert, but that is a keyword as of JDK 1.4.
-     */
+ */
     public static void assertTrue(boolean b) {
         if (!b) {
             throw newInternal("assert failed");
@@ -1757,7 +1738,7 @@ public class Util {
      * Throws an internal error with the given messagee if condition is not
      * true. It would be called assert, but that is a keyword as
      * of JDK 1.4.
-     */
+ */
     public static void assertTrue(boolean b, String message) {
         if (!b) {
             throw newInternal("assert failed: " + message);
@@ -1766,14 +1747,14 @@ public class Util {
 
     /**
      * Creates an internal error with a given message.
-     */
+ */
     public static RuntimeException newInternal(String message) {
         return new OlapRuntimeException(MessageFormat.format("Internal error: {0}", message));
     }
 
     /**
      * Creates an internal error with a given message and cause.
-     */
+ */
     public static RuntimeException newInternal(Throwable e, String message) {
         return new OlapRuntimeException(MessageFormat.format("Internal error: {0}", message), e);
     }
@@ -1781,7 +1762,7 @@ public class Util {
     /**
      * Creates a non-internal error. Currently implemented in terms of
      * internal errors, but later we will create resourced messages.
-     */
+ */
     public static RuntimeException newError(String message) {
         return newInternal(message);
     }
@@ -1789,7 +1770,7 @@ public class Util {
     /**
      * Creates a non-internal error. Currently implemented in terms of
      * internal errors, but later we will create resourced messages.
-     */
+ */
     public static RuntimeException newError(Throwable e, String message) {
         return newInternal(e, message);
     }
@@ -1799,7 +1780,7 @@ public class Util {
      * here.
      *
      * @param value Value
-     */
+ */
     public static RuntimeException unexpected(Enum value) {
         return Util.newInternal(
             new StringBuilder("Was not expecting value '").append(value)
@@ -1812,7 +1793,7 @@ public class Util {
      * tag) is satisfied.
      *
      * @param b The value of executing the condition
-     */
+ */
     public static void assertPrecondition(boolean b) {
         assertTrue(b);
     }
@@ -1828,7 +1809,7 @@ public class Util {
      *
      * @param b The value of executing the condition
      * @param condition The text of the condition
-     */
+ */
     public static void assertPrecondition(boolean b, String condition) {
         assertTrue(b, condition);
     }
@@ -1840,7 +1821,7 @@ public class Util {
      * tag) is satisfied.
      *
      * @param b The value of executing the condition
-     */
+ */
     public static void assertPostcondition(boolean b, String condition) {
         assertTrue(b, condition);
     }
@@ -1851,7 +1832,7 @@ public class Util {
      * {@link #getErrorMessage(Throwable,boolean)}, but does not print the
      * class name if the exception is derived from {@link java.sql.SQLException}
      * or is exactly a {@link java.lang.Exception}.
-     */
+ */
     public static String getErrorMessage(Throwable err) {
         boolean prependClassName =
             !(err instanceof java.sql.SQLException
@@ -1868,7 +1849,7 @@ public class Util {
      *   class name of the Java exception?  defaults to false, unless the error
      *   is derived from {@link java.sql.SQLException} or is exactly a {@link
      *   java.lang.Exception}
-     */
+ */
     public static String getErrorMessage(
         Throwable err,
         boolean prependClassName)
@@ -1894,7 +1875,7 @@ public class Util {
      * @param clazz Desired class
      * @param <T> Class
      * @return Cause of given class, or null
-     */
+ */
     public static <T extends Throwable>
     T getMatchingCause(Throwable e, Class<T> clazz) {
         for (;;) {
@@ -1911,7 +1892,7 @@ public class Util {
 
     /**
      * Converts an expression to a string.
-     */
+ */
     public static String unparse(Expression exp) {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
@@ -1921,7 +1902,7 @@ public class Util {
 
     /**
      * Converts an query to a string.
-     */
+ */
     public static String unparse(Query query) {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new QueryPrintWriter(sw);
@@ -1931,7 +1912,7 @@ public class Util {
 
     /**
      * Creates a file-protocol URL for the given file.
-     */
+ */
     public static URL toURL(File file) throws MalformedURLException {
         String path = file.getAbsolutePath();
         // This is a bunch of weird code that is required to
@@ -1953,7 +1934,7 @@ public class Util {
 
     /**
      * Combines two integers into a hash code.
-     */
+ */
     public static int hash(int i, int j) {
         return (i << 4) ^ j;
     }
@@ -1961,7 +1942,7 @@ public class Util {
     /**
      * Computes a hash code from an existing hash code and an object (which
      * may be null).
-     */
+ */
     public static int hash(int h, Object o) {
         int k = (o == null) ? 0 : o.hashCode();
         return ((h << 4) | h) ^ k;
@@ -1970,7 +1951,7 @@ public class Util {
     /**
      * Computes a hash code from an existing hash code and an array of objects
      * (which may be null).
-     */
+ */
     public static int hashArray(int h, Object [] a) {
         // The hashcode for a null array and an empty array should be different
         // than h, so use magic numbers.
@@ -1995,7 +1976,7 @@ public class Util {
      * @param a0 First array
      * @param as Zero or more subsequent arrays
      * @return Array containing all elements
-     */
+ */
     public static <T> T[] appendArrays(
         T[] a0,
         T[]... as)
@@ -2022,7 +2003,7 @@ public class Util {
      * @return New array containing original array plus element
      *
      * @see #appendArrays
-     */
+ */
     public static <T> T[] append(T[] a, T o) {
         T[] a2 = Arrays.copyOf(a, a.length + 1);
         a2[a.length] = o;
@@ -2037,7 +2018,7 @@ public class Util {
      * @param newLength the length of the copy to be returned
      * @return a copy of the original array, truncated or padded with zeros
      *     to obtain the specified length
-     */
+ */
     public static double[] copyOf(double[] original, int newLength) {
         double[] copy = new double[newLength];
         System.arraycopy(
@@ -2053,7 +2034,7 @@ public class Util {
      * @param newLength the length of the copy to be returned
      * @return a copy of the original array, truncated or padded with zeros
      *     to obtain the specified length
-     */
+ */
     public static int[] copyOf(int[] original, int newLength) {
         int[] copy = new int[newLength];
         System.arraycopy(
@@ -2069,7 +2050,7 @@ public class Util {
      * @param newLength the length of the copy to be returned
      * @return a copy of the original array, truncated or padded with zeros
      *     to obtain the specified length
-     */
+ */
     public static long[] copyOf(long[] original, int newLength) {
         long[] copy = new long[newLength];
         System.arraycopy(
@@ -2080,7 +2061,7 @@ public class Util {
     /**
      * Creates a very simple implementation of {@link Validator}. (Only
      * useful for resolving trivial expressions.)
-     */
+ */
     public static Validator createSimpleValidator(final FunctionService functionService) {
         return new Validator() {
             @Override
@@ -2177,7 +2158,7 @@ public class Util {
      * @param bufferSize size of buffer to allocate for reading.
      * @return content of Reader as String
      * @throws IOException on I/O error
-     */
+ */
     public static String readFully(final Reader rdr, final int bufferSize)
         throws IOException
     {
@@ -2204,7 +2185,7 @@ public class Util {
      * @param bufferSize size of buffer to allocate for reading.
      * @return content of stream as an array of bytes
      * @throws IOException on I/O error
-     */
+ */
     public static byte[] readFully(final InputStream in, final int bufferSize)
         throws IOException
     {
@@ -2237,7 +2218,7 @@ public class Util {
      * @param map Key/value map
      * @return Contents of URL with tokens substituted
      * @throws IOException on I/O error
-     */
+ */
     public static String readURL(final String urlStr, Map<String, String> map)
         throws IOException
     {
@@ -2265,7 +2246,7 @@ public class Util {
      * @param map Key/value map
      * @return Contents of URL with tokens substituted
      * @throws IOException on I/O error
-     */
+ */
     public static String readURL(
         final URL url,
         Map<String, String> map)
@@ -2287,7 +2268,7 @@ public class Util {
      * @param text Source string
      * @param env Map of key-value pairs
      * @return String with tokens substituted
-     */
+ */
     public static String replaceProperties(
         String text,
         Map<String, String> env)
@@ -2350,7 +2331,7 @@ public class Util {
      *
      * @param set Set
      * @return Set of desired type
-     */
+ */
     @SuppressWarnings({"unchecked"})
     public static <T> Set<T> cast(Set<?> set) {
         return (Set<T>) set;
@@ -2361,7 +2342,7 @@ public class Util {
      *
      * @param list List
      * @return List of desired type
-     */
+ */
     @SuppressWarnings({"unchecked"})
     public static <T> List<T> cast(List<?> list) {
         return (List<T>) list;
@@ -2376,7 +2357,7 @@ public class Util {
      * @param <T> Element type
      * @return Whether all not-null elements of the collection are instances of
      *   element type
-     */
+ */
     public static <T> boolean canCast(
         Collection<?> collection,
         Class<T> clazz)
@@ -2396,7 +2377,7 @@ public class Util {
      *
      * @param clazz Enumerated type
      * @param name Name of constant
-     */
+ */
     public static <E extends Enum<E>> E lookup(Class<E> clazz, String name) {
         return lookup(clazz, name, null);
     }
@@ -2409,7 +2390,7 @@ public class Util {
      * @param name Name of constant
      * @param defaultValue Default value if constant is not found
      * @return Value, or null if name is null or value does not exist
-     */
+ */
     public static <E extends Enum<E>> E lookup(
         Class<E> clazz, String name, E defaultValue)
     {
@@ -2434,7 +2415,7 @@ public class Util {
      *
      * @param resultSize Result limit
      * @throws ResourceLimitExceededException
-     */
+ */
     public static void checkCJResultLimit(long resultSize) {
         int resultLimit = SystemWideProperties.instance().ResultLimit;
 
@@ -2459,7 +2440,7 @@ public class Util {
      * the collection.
      *
      * @param <T> Element type
-     */
+ */
     public static class GcIterator<T> implements Iterator<T> {
         private final Iterator<? extends Reference<T>> iterator;
         private boolean hasNext;
@@ -2477,7 +2458,7 @@ public class Util {
          * @param referenceIterable Collection of references
          * @param <T2> element type
          * @return iterable over collection
-         */
+ */
         public static <T2> Iterable<T2> over(
             final Iterable<? extends Reference<T2>> referenceIterable)
         {
@@ -2525,7 +2506,7 @@ public class Util {
     /**
      * This class implements the Knuth-Morris-Pratt algorithm
      * to search within a byte array for a token byte array.
-     */
+ */
     public static class ByteMatcher {
         private final int[] matcher;
         public final byte[] key;
@@ -2539,7 +2520,7 @@ public class Util {
          * within the array.
          * @param a An array of bytes to search for.
          * @return -1 if not found, or the index (0 based) of the match.
-         */
+ */
         public int match(byte[] a) {
             int j = 0;
             for (int i = 0; i < a.length; i++) {
@@ -2585,7 +2566,7 @@ public class Util {
      * The returned map is to be considered immutable. It will
      * throw an {@link UnsupportedOperationException} if attempts to
      * modify it are made.
-     */
+ */
     public static <K, V> Map<K, V> toNullValuesMap(List<K> list) {
         return new NullValuesMap<>(list);
     }
@@ -2707,7 +2688,7 @@ public class Util {
    * @param title
    * @param calc
    * @param timing
-   */
+ */
   public static void explain( ProfileHandler handler, String title, Calc<?> calc, QueryTiming timing ) {
     if ( handler == null ) {
       return;
@@ -2743,7 +2724,7 @@ public class Util {
    * @param connection Connection providing execution context
    * @param schemaReader CatalogReader to wrap
    * @return Wrapped CatalogReader with automatic execution context management
-   */
+ */
   public static CatalogReader executionCatalogReader(
       org.eclipse.daanse.olap.api.connection.Connection connection,
       final CatalogReader schemaReader)
@@ -2757,7 +2738,7 @@ public class Util {
     /**
      * Comparable value, equal only to itself. Used to represent the NULL value,
      * as returned from a SQL query.
-     */
+ */
     private static final class UtilComparable
         implements Comparable, Serializable
     {

--- a/common/src/main/java/org/eclipse/daanse/olap/fun/FunUtil.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/fun/FunUtil.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.access.AccessMember;
 import org.eclipse.daanse.olap.api.agg.Segment;
@@ -74,6 +75,8 @@ import org.eclipse.daanse.olap.api.type.MemberType;
 import org.eclipse.daanse.olap.api.type.ScalarType;
 import org.eclipse.daanse.olap.api.type.TupleType;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.CompensatedSum;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.type.tuplebase.UnaryTupleList;
 import org.eclipse.daanse.olap.common.Util;
 import org.eclipse.daanse.olap.element.PropertyBase;
@@ -107,21 +110,15 @@ public class FunUtil extends Util {
   public static final NullMember NullMember = new NullMember();
 
 
-  /**
-   * Special value which indicates that a {@code double} computation has returned the MDX EMPTY value. See {@link
-   * DoubleCalc}.
-   */
-  public static final double DOUBLE_EMPTY = -0.000000012345;
-
 //  /**
 //   * Special value which indicates that an {@code int} computation has returned the MDX null value. See {@link
 //   * org.eclipse.daanse.olap.calc.api.IntegerCalc}.
-//   */
+// */
 //  public static final int INTEGER_NULL = Integer.MIN_VALUE + 1;
 
   /**
    * Null value in three-valued boolean logic. Actually, a placeholder until we actually implement 3VL.
-   */
+ */
   public static final boolean BOOLEAN_NULL = false;
     private final static String memberNotInLevelHierarchy = "The member ''{0}'' is not in the same hierarchy as the level ''{1}''.";
 
@@ -131,7 +128,7 @@ public class FunUtil extends Util {
    * @param functionMetaData  Function meta data
    * @param message Explanatory message
    * @return Exception that can be used as a cell result
-   */
+ */
   public static RuntimeException newEvalException(
 		  FunctionMetaData functionMetaData ,
     String message ) {
@@ -143,7 +140,7 @@ public class FunUtil extends Util {
    *
    * @param throwable Exception
    * @return Exception that can be used as a cell result
-   */
+ */
   public static RuntimeException newEvalException( Throwable throwable ) {
     return new DaanseEvaluationException(
       new StringBuilder(throwable.getClass().getName()).append(": ").append(throwable.getMessage()).toString() );
@@ -155,7 +152,7 @@ public class FunUtil extends Util {
    * @param message   Explanatory message
    * @param throwable Exception
    * @return Exception that can be used as a cell result
-   */
+ */
   public static RuntimeException newEvalException(
     String message,
     Throwable throwable ) {
@@ -188,7 +185,7 @@ public class FunUtil extends Util {
 
   /**
    * Returns an argument whose value is a literal.
-   */
+ */
 
   public static String getLiteralArg(
     ResolvedFunCall call,
@@ -232,7 +229,7 @@ public class FunUtil extends Util {
   /**
    * Returns the ordinal of a literal argument. If the argument does not belong to the supplied enumeration, returns
    * -1.
-   */
+ */
   public static <E extends Enum<E>> E getLiteralArg(
     ResolvedFunCall call,
     int i,
@@ -277,7 +274,7 @@ public class FunUtil extends Util {
    * Throws an error if the expressions don't have the same hierarchy.
    *
    * @throws DaanseEvaluationException if expressions don't have the same hierarchy
-   */
+ */
   public static void checkCompatible( Expression left, Expression right, FunctionDefinition funDef ) {
     final Type leftType = TypeUtil.stripSetType( left.getType() );
     final Type rightType = TypeUtil.stripSetType( right.getType() );
@@ -289,7 +286,7 @@ public class FunUtil extends Util {
 
   /**
    * Adds every element of {@code right} which is not in {@code set} to both {@code set} and {@code left}.
-   */
+ */
   public static void addUnique(
     TupleList left,
     TupleList right,
@@ -339,7 +336,7 @@ public class FunUtil extends Util {
    *
    * @param memberList Member list
    * @return List of non-calculated members
-   */
+ */
   static List<Member> removeCalculatedMembers( List<Member> memberList ) {
     List<Member> clone = new ArrayList<>();
     for ( Member member : memberList ) {
@@ -357,7 +354,7 @@ public class FunUtil extends Util {
    *
    * @param memberList Member list
    * @return List of non-calculated members
-   */
+ */
   public static TupleList removeCalculatedMembers( TupleList memberList ) {
     if ( memberList.getArity() == 1 ) {
       return new UnaryTupleList(
@@ -383,7 +380,7 @@ public class FunUtil extends Util {
    * Returns whether {@code m0} is an ancestor of {@code m1}.
    *
    * @param strict if true, a member is not an ancestor of itself
-   */
+ */
   public static boolean isAncestorOf( Member m0, Member m1, boolean strict ) {
     if ( strict ) {
       if ( m1 == null ) {
@@ -405,44 +402,15 @@ public class FunUtil extends Util {
    *
    * MDX requires a total order:
    *
-   * -inf &lt; NULL &lt; ... &lt; -1 &lt; ... &lt; 0 &lt; ... &lt; NaN &lt; +inf
+   * -inf &lt; ... &lt; -1 &lt; ... &lt; 0 &lt; ... &lt; NaN &lt; +inf
    *
-   * but this is different than Java semantics, specifically with regard to {@link Double#NaN}.
-   */
+   * which differs from Java semantics with regard to {@link Double#NaN}.
+   * A primitive {@code double} cannot carry MDX NULL; NULL
+   * ordering exists only at the boxed/object level
+   * ({@link #compareValues(Object, Object)}).
+ */
   public static int compareValues( double d1, double d2 ) {
-    if ( Double.isNaN( d1 ) ) {
-      if ( d2 == Double.POSITIVE_INFINITY ) {
-        return -1;
-      } else if ( Double.isNaN( d2 ) ) {
-        return 0;
-      } else {
-        return 1;
-      }
-    } else if ( Double.isNaN( d2 ) ) {
-      if ( d1 == Double.POSITIVE_INFINITY ) {
-        return 1;
-      } else {
-        return -1;
-      }
-    } else if ( d1 == d2 ) {
-      return 0;
-    } else if ( d1 == FunUtil.DOUBLE_NULL) {
-      if ( d2 == Double.NEGATIVE_INFINITY ) {
-        return 1;
-      } else {
-        return -1;
-      }
-    } else if ( d2 == FunUtil.DOUBLE_NULL) {
-      if ( d1 == Double.NEGATIVE_INFINITY ) {
-        return -1;
-      } else {
-        return 1;
-      }
-    } else if ( d1 < d2 ) {
-      return -1;
-    } else {
-      return 1;
-    }
+    return NullSemantics.compare( d1, d2 );
   }
 
   /**
@@ -454,48 +422,15 @@ public class FunUtil extends Util {
    * @param value0 First cell value
    * @param value1 Second cell value
    * @return -1, 0, or 1, depending upon whether first cell value is less than, equal to, or greater than the second
-   */
+ */
   public static int compareValues( Object value0, Object value1 ) {
-    if ( value0 == value1 ) {
-      return 0;
-    }
-    // null is less than anything else
-    if ( value0 == null ) {
-      return -1;
-    }
-    if ( value1 == null ) {
-      return 1;
-    }
-
-    if ( value0 == Util.valueNotReadyException ) {
-      // the left value is not in cache; continue as best as we can
-      return -1;
-    } else if ( value1 == Util.valueNotReadyException ) {
-      // the right value is not in cache; continue as best as we can
-      return 1;
-    } else if ( value0 == Util.nullValue ) {
-      return -1; // null == -infinity
-    } else if ( value1 == Util.nullValue ) {
-      return 1; // null == -infinity
-    } else if ( value0 instanceof String str) {
-      return str.compareToIgnoreCase( (String) value1 );
-    } else if ( value0 instanceof Number numberValue0) {
-      return FunUtil.compareValues(
-          numberValue0.doubleValue(),
-        ( (Number) value1 ).doubleValue() );
-    } else if ( value0 instanceof Date date) {
-      return date.compareTo( (Date) value1 );
-    } else if ( value0 instanceof OrderKey orderKey && value1 instanceof OrderKey orderKeyOther) {
-      return orderKey.compareTo( orderKeyOther);
-    } else {
-      throw Util.newInternal( "cannot compare " + value0 );
-    }
+    return NullSemantics.compareCellValues( value0, value1 );
   }
 
   /**
    * Turns the mapped values into relative values (percentages) for easy use by the general topOrBottom function. This
    * might also be a useful function in itself.
-   */
+ */
   public static void toPercent(
     TupleList members,
     Map<List<Member>, Object> mapMemberToValue ) {
@@ -520,7 +455,7 @@ public class FunUtil extends Util {
     }
   }
 
-  public static double percentile(
+  public static Double percentile(
     Evaluator evaluator,
     TupleList members,
     Calc exp,
@@ -529,7 +464,8 @@ public class FunUtil extends Util {
     if ( sw.errorCount > 0 ) {
       return Double.NaN;
     } else if ( sw.v.isEmpty() ) {
-      return FunUtil.DOUBLE_NULL;
+      // Percentile({}) is NULL — Java null.
+      return null;
     }
     double[] asArray = new double[ sw.v.size() ];
     for ( int i = 0; i < asArray.length; i++ ) {
@@ -587,8 +523,8 @@ public class FunUtil extends Util {
    * @param exp       Expression to rank members
    * @param range     Quartile (1, 2 or 3)
    *  range more or equals 1 and range less or equals 3
-   */
-  public static double quartile(
+ */
+  public static Double quartile(
     Evaluator evaluator,
     TupleList members,
     Calc exp,
@@ -599,7 +535,8 @@ public class FunUtil extends Util {
     if ( sw.errorCount > 0 ) {
       return Double.NaN;
     } else if ( sw.v.isEmpty() ) {
-      return FunUtil.DOUBLE_NULL;
+      // Quartile({}) is NULL — Java null.
+      return null;
     }
 
     double[] asArray = new double[ sw.v.size() ];
@@ -626,7 +563,7 @@ public class FunUtil extends Util {
     } else {
       final int size = sw.v.size();
       if ( size == 0 ) {
-        return Util.nullValue;
+        return null;
       } else {
         Double min = ( (Number) sw.v.get( 0 ) ).doubleValue();
         for ( int i = 1; i < size; i++ ) {
@@ -650,7 +587,7 @@ public class FunUtil extends Util {
     } else {
       final int size = sw.v.size();
       if ( size == 0 ) {
-        return Util.nullValue;
+        return null;
       } else {
         Double max = ( (Number) sw.v.get( 0 ) ).doubleValue();
         for ( int i = 1; i < size; i++ ) {
@@ -677,19 +614,19 @@ public class FunUtil extends Util {
     if ( sw.errorCount > 0 ) {
       return Double.NaN;
     } else if ( sw.v.isEmpty() ) {
-      return Util.nullValue;
+      return null;
     } else {
-      double stdev = 0.0;
+      CompensatedSum squaredDeviations = new CompensatedSum();
       double avg = FunUtil.avg( sw );
       for ( int i = 0; i < sw.v.size(); i++ ) {
-        stdev +=
-          Math.pow( ( ( (Number) sw.v.get( i ) ).doubleValue() - avg ), 2 );
+        double diff = ( (Number) sw.v.get( i ) ).doubleValue() - avg;
+        squaredDeviations.add( diff * diff );
       }
       int n = sw.v.size();
       if ( !biased ) {
         n--;
       }
-      return Double.valueOf( stdev / n );
+      return Double.valueOf( squaredDeviations.value() / n );
     }
   }
 
@@ -698,16 +635,16 @@ public class FunUtil extends Util {
     TupleList memberList,
     Calc exp1,
     Calc exp2 ) {
-    SetWrapper sw1 = FunUtil.evaluateSet( evaluator, memberList, exp1 );
-    SetWrapper sw2 = FunUtil.evaluateSet( evaluator, memberList, exp2 );
-    Object covar = FunUtil.covariance( sw1, sw2, false );
-    Object var1 = FunUtil.var( sw1, false ); // this should be false, yes?
-    Object var2 = FunUtil.var( sw2, false );
-
-    return ( (Number) covar ).doubleValue()
-      / Math.sqrt(
-      ( (Number) var1 ).doubleValue()
-        * ( (Number) var2 ).doubleValue() );
+    PairedValues pairs = FunUtil.evaluatePairs( evaluator, memberList, exp1, exp2 );
+    if ( pairs.errorCount > 0 || pairs.size() == 0 ) {
+      return Double.NaN;
+    }
+    // Pearson r over pairwise-complete observations: covariance and both
+    // variances are computed from the SAME aligned pairs.
+    double covar = pairs.covariance( false );
+    double var1 = pairs.variance1( false );
+    double var2 = pairs.variance2( false );
+    return covar / Math.sqrt( var1 * var2 );
   }
 
   public static Object covariance(
@@ -716,47 +653,106 @@ public class FunUtil extends Util {
     Calc exp1,
     Calc exp2,
     boolean biased ) {
-    final int savepoint = evaluator.savepoint();
-    SetWrapper sw1;
-    try {
-      sw1 = FunUtil.evaluateSet( evaluator, members, exp1 );
-    } finally {
-      evaluator.restore( savepoint );
+    PairedValues pairs = FunUtil.evaluatePairs( evaluator, members, exp1, exp2 );
+    if ( pairs.errorCount > 0 ) {
+      return Double.NaN;
     }
-    SetWrapper sw2;
-    try {
-      sw2 = FunUtil.evaluateSet( evaluator, members, exp2 );
-    } finally {
-      evaluator.restore( savepoint );
+    if ( pairs.size() == 0 ) {
+      return null;
     }
-    // todo: because evaluateSet does not add nulls to the SetWrapper, this
-    // solution may lead to mismatched lists and is therefore not robust
-    return FunUtil.covariance( sw1, sw2, biased );
+    return Double.valueOf( pairs.covariance( biased ) );
   }
 
+  /**
+   * Evaluates two expressions pairwise over the same tuples. A pair is kept
+   * only if BOTH values are non-NULL (pairwise deletion), which keeps x and
+   * y positionally aligned: dropping NULLs per set independently would
+   * silently pair values of different tuples whenever the NULL patterns
+   * differed.
+ */
+  private static PairedValues evaluatePairs(
+    Evaluator evaluator,
+    TupleList members,
+    Calc<?> calc1,
+    Calc<?> calc2 ) {
+    PairedValues pairs = new PairedValues();
+    final TupleCursor cursor = members.tupleCursor();
+    int currentIteration = 0;
+    Execution execution = evaluator.getQuery().getStatement().getCurrentExecution();
+    final int savepoint = evaluator.savepoint();
+    try {
+      while ( cursor.forward() ) {
+        CancellationChecker.checkCancelOrTimeout( currentIteration++, execution );
+        cursor.setContext( evaluator );
+        Object o1 = calc1.evaluate( evaluator );
+        Object o2 = calc2.evaluate( evaluator );
+        if ( o1 == NotLoaded.INSTANCE || o2 == NotLoaded.INSTANCE ) {
+          // dirty pass; keep iterating so the batching cell reader sees
+          // every dependent cell, but poison the result
+          pairs.errorCount++;
+        } else if ( NullSemantics.isNull( o1 ) || NullSemantics.isNull( o2 ) ) {
+          // pairwise deletion: skip the tuple entirely
+        } else if ( o1 instanceof Number n1 && o2 instanceof Number n2 ) {
+          pairs.add( n1.doubleValue(), n2.doubleValue() );
+        } else {
+          pairs.errorCount++;
+        }
+      }
+    } finally {
+      evaluator.restore( savepoint );
+    }
+    return pairs;
+  }
 
-  private static Object covariance(
-    SetWrapper sw1,
-    SetWrapper sw2,
-    boolean biased ) {
-    if ( sw1.v.size() != sw2.v.size() ) {
-      return Util.nullValue;
+  /** Aligned x/y samples for the paired statistics (Covariance, Correlation). */
+  private static final class PairedValues {
+    private final List<Double> x = new ArrayList<>();
+    private final List<Double> y = new ArrayList<>();
+    int errorCount;
+
+    void add( double v1, double v2 ) {
+      x.add( v1 );
+      y.add( v2 );
     }
-    double avg1 = FunUtil.avg( sw1 );
-    double avg2 = FunUtil.avg( sw2 );
-    double covar = 0.0;
-    for ( int i = 0; i < sw1.v.size(); i++ ) {
-      // all of this casting seems inefficient - can we make SetWrapper
-      // contain an array of double instead?
-      double diff1 = ( ( (Number) sw1.v.get( i ) ).doubleValue() - avg1 );
-      double diff2 = ( ( (Number) sw2.v.get( i ) ).doubleValue() - avg2 );
-      covar += ( diff1 * diff2 );
+
+    int size() {
+      return x.size();
     }
-    int n = sw1.v.size();
-    if ( !biased ) {
-      n--;
+
+    private static double mean( List<Double> values ) {
+      CompensatedSum sum = new CompensatedSum();
+      for ( Double v : values ) {
+        sum.add( v );
+      }
+      return sum.value() / values.size();
     }
-    return Double.valueOf( covar / n );
+
+    private static double squaredDeviations( List<Double> values, double mean ) {
+      CompensatedSum sum = new CompensatedSum();
+      for ( Double v : values ) {
+        double diff = v - mean;
+        sum.add( diff * diff );
+      }
+      return sum.value();
+    }
+
+    double covariance( boolean biased ) {
+      double meanX = mean( x );
+      double meanY = mean( y );
+      CompensatedSum covar = new CompensatedSum();
+      for ( int i = 0; i < x.size(); i++ ) {
+        covar.add( ( x.get( i ) - meanX ) * ( y.get( i ) - meanY ) );
+      }
+      return covar.value() / ( biased ? x.size() : x.size() - 1 );
+    }
+
+    double variance1( boolean biased ) {
+      return squaredDeviations( x, mean( x ) ) / ( biased ? x.size() : x.size() - 1 );
+    }
+
+    double variance2( boolean biased ) {
+      return squaredDeviations( y, mean( y ) ) / ( biased ? y.size() : y.size() - 1 );
+    }
   }
 
   public static Object stdev(
@@ -779,7 +775,7 @@ public class FunUtil extends Util {
       return Double.NaN;
     } else {
         return (sw.v.isEmpty())
-            ? Util.nullValue
+            ? null
             : Double.valueOf(FunUtil.avg(sw));
     }
   }
@@ -787,23 +783,26 @@ public class FunUtil extends Util {
   // TODO: parameterize inclusion of nulls; also, maybe make _avg a method of
   // setwrapper, so we can cache the result (i.e. for correl)
   private static double avg(SetWrapper sw ) {
-    double sum = 0.0;
+    CompensatedSum sum = new CompensatedSum();
     for ( int i = 0; i < sw.v.size(); i++ ) {
-      sum += ( (Number) sw.v.get( i ) ).doubleValue();
+      sum.add( ( (Number) sw.v.get( i ) ).doubleValue() );
     }
     // TODO: should look at context and optionally include nulls
-    return sum / sw.v.size();
+    return sum.value() / sw.v.size();
   }
 
   public static Object sum(
     Evaluator evaluator,
     TupleList members,
     Calc exp ) {
-    double d = FunUtil.sumDouble( evaluator, members, exp );
-    return d == FunUtil.DOUBLE_NULL ? Util.nullValue : Double.valueOf( d );
+    return FunUtil.sumDouble( evaluator, members, exp );
   }
 
-  public static double sumDouble(
+  /**
+   * Sums {@code exp} over {@code members}. Returns Java {@code null} (MDX
+   * NULL) for an empty set.
+ */
+  public static Double sumDouble(
     Evaluator evaluator,
     TupleList members,
     Calc exp ) {
@@ -811,17 +810,22 @@ public class FunUtil extends Util {
     if ( sw.errorCount > 0 ) {
       return Double.NaN;
     } else if ( sw.v.isEmpty() ) {
-      return FunUtil.DOUBLE_NULL;
+      return null;
     } else {
-      double sum = 0.0;
+      CompensatedSum sum = new CompensatedSum();
       for ( int i = 0; i < sw.v.size(); i++ ) {
-        sum += ( (Number) sw.v.get( i ) ).doubleValue();
+        sum.add( ( (Number) sw.v.get( i ) ).doubleValue() );
       }
-      return sum;
+      return sum.value();
     }
   }
 
-  public static double sumDouble(
+  /**
+   * Sums {@code exp} over {@code iterable}. Returns Java {@code null} (MDX
+   * NULL) for an empty set — there is no primitive sentinel
+   * anymore.
+ */
+  public static Double sumDouble(
     Evaluator evaluator,
     TupleIterable iterable,
     Calc exp ) {
@@ -829,13 +833,13 @@ public class FunUtil extends Util {
     if ( sw.errorCount > 0 ) {
       return Double.NaN;
     } else if ( sw.v.isEmpty() ) {
-      return FunUtil.DOUBLE_NULL;
+      return null;
     } else {
-      double sum = 0.0;
+      CompensatedSum sum = new CompensatedSum();
       for ( int i = 0; i < sw.v.size(); i++ ) {
-        sum += ( (Number) sw.v.get( i ) ).doubleValue();
+        sum.add( ( (Number) sw.v.get( i ) ).doubleValue() );
       }
-      return sum;
+      return sum.value();
     }
   }
 
@@ -876,7 +880,7 @@ public class FunUtil extends Util {
    * values.
    *
    *  exp != null
-   */
+ */
   static SetWrapper evaluateSet(
     Evaluator evaluator,
     TupleIterable members,
@@ -896,9 +900,9 @@ public class FunUtil extends Util {
         currentIteration++, execution );
       cursor.setContext( evaluator );
       Object o = calc.evaluate( evaluator );
-      if ( o == null || o == Util.nullValue ) {
+      if ( NullSemantics.isNull( o ) ) {
         retval.nullCount++;
-      } else if ( o == Util.valueNotReadyException ) {
+      } else if ( o == NotLoaded.INSTANCE ) {
         // Carry on summing, so that if we are running in a
         // BatchingCellReader, we find out all the dependent cells we
         // need
@@ -920,7 +924,7 @@ public class FunUtil extends Util {
    * might be null) - this allows higher level code to determine how to handle the lack of data rather than having a
    * non-equal number (if one is plotting x,y values it helps to have the same number and know where a potential gap is
    * the data is.
-   */
+ */
   public static SetWrapper[] evaluateSet(
     Evaluator evaluator,
     TupleList list,
@@ -944,10 +948,7 @@ public class FunUtil extends Util {
         DoubleCalc calc = calcs[ i ];
         SetWrapper retval = retvals[ i ];
         Double o = calc.evaluate( evaluator );
-        if (o == null) {
-          LOGGER.debug("Calc evaluated to null: {}", calc);
-        }
-        if ( o == FunUtil.DOUBLE_NULL) {
+        if ( NullSemantics.isNull( o ) ) {
           retval.nullCount++;
           retval.v.add( null );
         } else {
@@ -1019,7 +1020,7 @@ public class FunUtil extends Util {
    * @param ancestorMember The cousin's ancestor.
    * @return The child of {@code ancestorMember} in the same position under {@code ancestorMember} as {@code member} is
    * under its parent.
-   */
+ */
   public static Member cousin(
     CatalogReader schemaReader,
     Member member,
@@ -1079,7 +1080,7 @@ public class FunUtil extends Util {
    * @param targetLevel The desired targetLevel of the ancestor. If {@code null}, then the distance completely
    *                    determines the desired ancestor.
    * @return The ancestor member, or {@code null} if no such ancestor exists.
-   */
+ */
   public static Member ancestor(
     Evaluator evaluator,
     Member member,
@@ -1160,7 +1161,7 @@ public class FunUtil extends Util {
    * @param m1 First member
    * @param m2 Second member
    * @return -1 if m1 collates less than m2, 1 if m1 collates after m2, 0 if m1 == m2.
-   */
+ */
   public static int compareSiblingMembers( Member m1, Member m2 ) {
     // calculated members collate after non-calculated
     final boolean calculated1 = m1.isCalculatedInQuery();
@@ -1191,7 +1192,7 @@ public class FunUtil extends Util {
 
   /**
    * Returns whether one of the members in a tuple is null.
-   */
+ */
   public static boolean tupleContainsNullMember( Member[] tuple ) {
     for ( Member member : tuple ) {
       if ( member.isNull() ) {
@@ -1203,7 +1204,7 @@ public class FunUtil extends Util {
 
   /**
    * Returns whether one of the members in a tuple is null.
-   */
+ */
   public static boolean tupleContainsNullMember( List<Member> tuple ) {
     for ( Member member : tuple ) {
       if ( member.isNull() ) {
@@ -1240,7 +1241,7 @@ public class FunUtil extends Util {
    * @param newArgs   Output parameter for the resolved arguments
    * @param operationAtom      Operation Atom
    * @return resolved function definition
-   */
+ */
   public static FunctionDefinition resolveFunArgs(
     Validator validator,
     FunctionDefinition funDef,
@@ -1264,7 +1265,7 @@ public class FunUtil extends Util {
    * @param validator Validator used to validate function arguments and resolve the function
    * @param funDef    Function definition, or null to deduce definition from name, syntax and argument types
    * @param args      Arguments to the function
-   */
+ */
   private static void checkNativeCompatible(
     Validator validator,
     FunctionDefinition funDef,
@@ -1336,7 +1337,7 @@ public class FunUtil extends Util {
    * The members are allowed to be in different positions. For example,
    * ([Gender].[M], [Store].[USA]) IS ([Store].[USA],
    * [Gender].[M]) returns {@code true}.
-   */
+ */
   public static boolean equalTuple( Member[] members0, Member[] members1 ) {
     final int count = members0.length;
     if ( count != members1.length ) {
@@ -1394,7 +1395,7 @@ public class FunUtil extends Util {
    * @param evaluator          Evaluator, determines non-empty criteria
    * @param level              Level
    * @param includeCalcMembers Whether to include calculated members
-   */
+ */
   static List<Member> getNonEmptyLevelMembers(
     final Evaluator evaluator,
     final Level level,
@@ -1484,7 +1485,7 @@ public class FunUtil extends Util {
    * @param members     Output array of members
    * @param hierarchies Hierarchies of the members
    * @return Position where parsing ended in string
-   */
+ */
   private static int parseTuple(
     final Evaluator evaluator,
     String string,
@@ -1512,7 +1513,7 @@ public class FunUtil extends Util {
    * @param string      String to parse
    * @param hierarchies Hierarchies of the members
    * @return Tuple represented as array of members
-   */
+ */
   public static Member[] parseTuple(
     Evaluator evaluator,
     String string,
@@ -1575,7 +1576,7 @@ public class FunUtil extends Util {
    *
    * @param exp Expression
    * @return Whether worth caching
-   */
+ */
   public static boolean worthCaching( Expression exp ) {
     // Literal is not worth caching.
     if ( exp instanceof Literal ) {
@@ -1611,7 +1612,7 @@ public class FunUtil extends Util {
    * @return true if each member from leftTuple is somewhere in the hierarchy chain of the corresponding member from
    * rightTuple, false otherwise. If there is no explicit corresponding member from either right or left, then the
    * default member is used.
-   */
+ */
   public static boolean existsInTuple(
     final List<Member> leftTuple, final List<Member> rightTuple,
     final List<Hierarchy> leftHierarchies,
@@ -1657,7 +1658,7 @@ public class FunUtil extends Util {
    * @param tuple            tuple containing the target member
    * @param tupleHierarchies list of the hierarchies explicitly contained in the tuple, in the same order.
    * @return target member
-   */
+ */
   private static Member getCorrespondingMember(
     final Member member, final List<Member> tuple,
     final List<Hierarchy> tupleHierarchies,
@@ -1703,11 +1704,11 @@ public class FunUtil extends Util {
    *
    * Nulls compare last, exceptions (including the
    * object which indicates the the cell is not in the cache yet) next, then numbers and strings are compared by value.
-   */
+ */
   public static class DescendingValueComparator implements Comparator<Object> {
     /**
      * The singleton.
-     */
+ */
     public static final DescendingValueComparator instance =
       new DescendingValueComparator();
 
@@ -1719,7 +1720,7 @@ public class FunUtil extends Util {
 
   /**
    * Null member of unknown hierarchy.
-   */
+ */
   private static class NullMember implements Member {
     @Override
 	public Member getParentMember() {

--- a/common/src/main/java/org/eclipse/daanse/olap/fun/sort/HierarchicalTupleKeyComparator.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/fun/sort/HierarchicalTupleKeyComparator.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
-import org.eclipse.daanse.olap.common.Util;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 
 class HierarchicalTupleKeyComparator extends TupleExpMemoComparator {
 
@@ -51,10 +51,10 @@ class HierarchicalTupleKeyComparator extends TupleExpMemoComparator {
   private int compareMemberOrderKeysHierarchically(
     OrderKey k1, OrderKey k2 ) {
     // null is less than anything else
-    if ( k1 == Util.nullValue ) {
+    if ( NullSemantics.isNull(k1) ) {
       return -1;
     }
-    if ( k2 == Util.nullValue ) {
+    if ( NullSemantics.isNull(k2) ) {
       return 1;
     }
     Member m1 = k1.member;

--- a/common/src/main/java/org/eclipse/daanse/olap/fun/sort/MemberComparator.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/fun/sort/MemberComparator.java
@@ -35,7 +35,6 @@ import java.util.Objects;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
-import org.eclipse.daanse.olap.common.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,17 +65,15 @@ abstract class MemberComparator implements Comparator<Member> {
     return descMask * c;
   }
 
-  // applies the Calc to a member, memorizing results
+  // applies the Calc to a member, memorizing results; MDX NULL results are
+  // Java null and must be memorized too, hence the containsKey probe
   protected Object eval( Member m ) {
-    Object val = valueMap.get( m );
-    if ( val == null ) {
-      evaluator.setContext( m );
-      val = exp.evaluate( evaluator );
-      if ( val == null ) {
-        val = Util.nullValue;
-      }
-      valueMap.put( m, val );
+    if ( valueMap.containsKey( m ) ) {
+      return valueMap.get( m );
     }
+    evaluator.setContext( m );
+    Object val = exp.evaluate( evaluator );
+    valueMap.put( m, val );
     return val;
   }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/fun/sort/Sorter.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/fun/sort/Sorter.java
@@ -27,7 +27,6 @@
 
 package org.eclipse.daanse.olap.fun.sort;
 
-import static org.eclipse.daanse.olap.common.Util.DOUBLE_NULL;
 import static org.eclipse.daanse.olap.common.Util.newInternal;
 
 import java.time.LocalDateTime;
@@ -53,6 +52,7 @@ import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.execution.Execution;
 import org.eclipse.daanse.olap.api.type.ScalarType;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.type.tuplebase.DelegatingTupleList;
 import org.eclipse.daanse.olap.calc.base.type.tuplebase.TupleCollections;
 import org.eclipse.daanse.olap.common.SystemWideProperties;
@@ -82,7 +82,7 @@ public class Sorter {
    * @param memberList List to be populated with members, or null
    * @param parentsToo If true, evaluate the expression for all ancestors of the members as well exp != null
    *                   exp.getType() instanceof ScalarType
-   */
+ */
   static Map<Member, Object> evaluateMembers(
     Evaluator evaluator,
     Calc exp,
@@ -100,9 +100,6 @@ public class Sorter {
         while ( true ) {
           evaluator.setContext( member );
           Object result = exp.evaluate( evaluator );
-          if ( result == null ) {
-            result = Util.nullValue;
-          }
           mapMemberToValue.put( member, result );
           if ( !parentsToo ) {
             break;
@@ -128,7 +125,7 @@ public class Sorter {
    * @param evaluator Evaluation context
    * @param exp       Expression to evaluate
    * @param tuples    List of tuples exp != null exp.getType() instanceof ScalarType
-   */
+ */
   public static Map<List<Member>, Object> evaluateTuples(
     Evaluator evaluator,
     Calc exp,
@@ -142,9 +139,6 @@ public class Sorter {
       for ( List<Member> tuple : tuples ) {
         evaluator.setContext( tuple );
         Object result = exp.evaluate( evaluator );
-        if ( result == null ) {
-          result = Util.nullValue;
-        }
         mapMemberToValue.put( tuple, result );
       }
       return mapMemberToValue;
@@ -172,7 +166,7 @@ public class Sorter {
    * @param desc       Whether to sort descending
    * @param brk        Whether to break
    * @return sorted list (never null)
-   */
+ */
   public static List<Member> sortMembers(
     Evaluator evaluator,
     Iterable<Member> memberIter,
@@ -237,7 +231,7 @@ public class Sorter {
    * OrderSet function.
    *
    * NOTE: Does not preserve the contents of the validator.
-   */
+ */
   public static List<Member> sortMembers(
     Evaluator evaluator,
     Iterable<Member> memberIter,
@@ -299,7 +293,7 @@ public class Sorter {
    * @param brk           Whether to break
    * @param arity         Number of members in each tuple
    * @return sorted list (never null)
-   */
+ */
   public static TupleList sortTuples(
     Evaluator evaluator,
     TupleIterable tupleIterable,
@@ -377,7 +371,7 @@ public class Sorter {
    * @param limit     maximum count of members to return.
    * @param desc      true to sort descending (and find TopCount), false to sort ascending (and find BottomCount).
    * @return the top or bottom members, as a new list.
-   */
+ */
   public static List<Member> partiallySortMembers(
     Evaluator evaluator,
     List<Member> list,
@@ -413,7 +407,7 @@ public class Sorter {
    * Helper function to sort a list of tuples according to a list of expressions and a list of sorting flags.
    *
    * NOTE: This function does not preserve the contents of the validator.
-   */
+ */
   public static TupleList sortTuples(
     Evaluator evaluator,
     TupleIterable tupleIter,
@@ -438,7 +432,7 @@ public class Sorter {
 
   /*
    * ONLY VisibleForTesting
-   */
+ */
   static Comparator<List<Member>> applySortSpecToComparator( Evaluator evaluator, int arity, Comparator<List<Member>> chain,
                                          SortKeySpec key ) {
     boolean brk = key.getDirection().brk;
@@ -494,7 +488,7 @@ public class Sorter {
    * @param limit     maximum count of tuples to return.
    * @param desc      true to sort descending (and find TopCount), false to sort ascending (and find BottomCount).
    * @return the top or bottom tuples, as a new list.
-   */
+ */
   public static List<List<Member>> partiallySortTuples(
     Evaluator evaluator,
     TupleList list,
@@ -517,7 +511,7 @@ public class Sorter {
    * @param memberList List of members
    * @param post       Whether to sort in post order; if false, sorts in pre order
    * @see #hierarchizeTupleList(org.eclipse.daanse.olap.api.calc.tuple.TupleList, boolean)
-   */
+ */
   public static void hierarchizeMemberList(
     List<Member> memberList,
     boolean post ) {
@@ -535,7 +529,7 @@ public class Sorter {
    * @param tupleList List of tuples
    * @param post      Whether to sort in post order; if false, sorts in pre order
    * @see #hierarchizeMemberList(java.util.List, boolean)
-   */
+ */
   public static TupleList hierarchizeTupleList(
     TupleList tupleList,
     boolean post ) {
@@ -562,45 +556,17 @@ public class Sorter {
    *
    * MDX requires a total order:
    *
-   * -inf &lt; NULL &lt; ... &lt; -1 &lt; ... &lt; 0 &lt; ... &lt; NaN &lt; +inf
+   * -inf &lt; ... &lt; -1 &lt; ... &lt; 0 &lt; ... &lt; NaN &lt; +inf
    *
-   * but this is different than Java semantics, specifically with regard to {@link Double#NaN}.
-   */
+   * which differs from Java semantics with regard to {@link Double#NaN}.
+   * A primitive {@code double} cannot carry MDX NULL; NULL
+   * ordering exists only at the boxed/object level
+   * ({@link #compareValues(Object, Object)}).
+ */
   public static int compareValues( double d1, double d2 ) {
-    if ( Double.isNaN( d1 ) ) {
-      if ( d2 == Double.POSITIVE_INFINITY ) {
-        return -1;
-      } else if ( Double.isNaN( d2 ) ) {
-        return 0;
-      } else {
-        return 1;
-      }
-    } else if ( Double.isNaN( d2 ) ) {
-      if ( d1 == Double.POSITIVE_INFINITY ) {
-        return 1;
-      } else {
-        return -1;
-      }
-    } else if ( d1 == d2 ) {
-      return 0;
-    } else if ( d1 == DOUBLE_NULL) {
-      if ( d2 == Double.NEGATIVE_INFINITY ) {
-        return 1;
-      } else {
-        return -1;
-      }
-    } else if ( d2 == DOUBLE_NULL) {
-      if ( d1 == Double.NEGATIVE_INFINITY ) {
-        return -1;
-      } else {
-        return 1;
-      }
-    } else if ( d1 < d2 ) {
-      return -1;
-    } else {
-      return 1;
-    }
+    return NullSemantics.compare( d1, d2 );
   }
+
 
   /**
    * Compares two cell values.
@@ -611,54 +577,9 @@ public class Sorter {
    * @param value0 First cell value
    * @param value1 Second cell value
    * @return -1, 0, or 1, depending upon whether first cell value is less than, equal to, or greater than the second
-   */
+ */
   public static int compareValues( Object value0, Object value1 ) {
-    if ( value0 == value1 ) {
-      return 0;
-    }
-    // null is less than anything else
-    if ( value0 == null ) {
-      return -1;
-    }
-    if ( value1 == null ) {
-      return 1;
-    }
-
-    if ( value0 == Util.valueNotReadyException ) {
-      // the left value is not in cache; continue as best as we can
-      return -1;
-    } else if ( value1 == Util.valueNotReadyException ) {
-      // the right value is not in cache; continue as best as we can
-      return 1;
-    } else if ( value0 == Util.nullValue ) {
-      return -1; // null == -infinity
-    } else if ( value1 == Util.nullValue ) {
-      return 1; // null == -infinity
-    } else if ( value0 instanceof String ) {
-      return ( (String) value0 ).compareToIgnoreCase( (String) value1 );
-    } else if ( value0 instanceof Number ) {
-      return Sorter.compareValues(
-        ( (Number) value0 ).doubleValue(),
-        ( (Number) value1 ).doubleValue() );
-    } else if ( value0 instanceof Date ) {
-      return ( (Date) value0 ).compareTo( (Date) value1 );
-    } else if ( value0 instanceof LocalDateTime ) {
-        return ( (LocalDateTime) value0 ).compareTo( (LocalDateTime) value1 );
-    } else if ( value0 instanceof OrderKey orderKey0 && value1 instanceof OrderKey orderKey1 ) {
-      return orderKey0.compareTo( orderKey1);
-    } else {
-      throw newInternal( "cannot compare " + value0 );
-    }
-  }
-
-
-  /**
-   * Converts a double (primitive) value to a Double. DoubleNull becomes null.
-   */
-  public static Double box( double d ) {
-    return d == DOUBLE_NULL
-      ? null
-      : d;
+    return NullSemantics.compareCellValues( value0, value1 );
   }
 
 
@@ -672,7 +593,7 @@ public class Sorter {
    * @param post Whether to sortMembers in postfix order. If true, a parent will sortMembers immediately after its last
    *             child. If false, a parent will sortMembers immediately before its first child.
    * @return -1 if m1 collates before m2, 0 if m1 equals m2, 1 if m1 collates after m2
-   */
+ */
   public static int compareHierarchically(
     Member m1,
     Member m2,
@@ -744,7 +665,7 @@ public class Sorter {
    * @param m1 First member
    * @param m2 Second member
    * @return -1 if m1 collates less than m2, 1 if m1 collates after m2, 0 if m1 == m2.
-   */
+ */
   public static int compareSiblingMembers( Member m1, Member m2 ) {
     // calculated members collate after non-calculated
     final boolean calculated1 = m1.isCalculatedInQuery();
@@ -791,7 +712,7 @@ public class Sorter {
    *
    * @param items will be partially-sorted in place
    * @param comp  a Comparator; null means use natural comparison
-   */
+ */
   static <T> void partialSort( T[] items, Comparator<T> comp, int limit ) {
     if ( comp == null ) {
       //noinspection unchecked
@@ -803,7 +724,7 @@ public class Sorter {
 
   /**
    * Stable partial sort of a list. Returns the desired head of the list.
-   */
+ */
   public static <T> List<T> stablePartialSort(
     final List<T> list, final Comparator<T> comp, int limit ) {
     return stablePartialSort( list, comp, limit, 0 );
@@ -811,7 +732,7 @@ public class Sorter {
 
   /**
    * Stable partial sort of a list, using a specified algorithm.
-   */
+ */
   public static <T> List<T> stablePartialSort(
     final List<T> list, final Comparator<T> comp, int limit, int algorithm ) {
     assert limit <= list.size();
@@ -843,7 +764,7 @@ public class Sorter {
   /**
    * Partial sort an array by sorting it and returning the first {@code limit} elements. Fastest approach if limit is a
    * significant fraction of the list.
-   */
+ */
   public static <T> List<T> stablePartialSortArray(
     final List<T> list, final Comparator<T> comp, int limit ) {
     ArrayList<T> list2 = new ArrayList<>( list );
@@ -853,7 +774,7 @@ public class Sorter {
 
   /**
    * Marc's original algorithm for stable partial sort of a list. Now superseded by {@link #stablePartialSortJulian}.
-   */
+ */
   public static <T> List<T> stablePartialSortMarc(
     final List<T> list, final Comparator<T> comp, int limit ) {
     assert limit >= 0;
@@ -910,7 +831,7 @@ public class Sorter {
    * @param limit Maximum number of items to return
    * @param <T>   Element type
    * @return Sorted list, containing at most limit items
-   */
+ */
   public static <T> List<T> stablePartialSortJulian(
     final List<T> list, final Comparator<T> comp, int limit ) {
     final Comparator<ObjIntPair<T>> comp2 =
@@ -953,7 +874,7 @@ public class Sorter {
 
   /**
    * Enumeration of the flags allowed to the {@code ORDER} MDX function.
-   */
+ */
   public enum SorterFlag {
     ASC( false, false ),
     DESC( true, false ),
@@ -980,7 +901,7 @@ public class Sorter {
    *
    * Similar to {@link org.eclipse.daanse.olap.util.Pair}, but saves boxing overhead of converting
    * {@code int} to {@link Integer}.
-   */
+ */
   public static class ObjIntPair<T> {
     final T t;
     final int i;

--- a/common/src/main/java/org/eclipse/daanse/olap/fun/sort/TupleExpMemoComparator.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/fun/sort/TupleExpMemoComparator.java
@@ -37,7 +37,6 @@ import java.util.List;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
-import org.eclipse.daanse.olap.common.Util;
 import org.eclipse.daanse.olap.util.CancellationChecker;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -66,6 +65,12 @@ abstract class TupleExpMemoComparator extends TupleComparator.TupleExpComparator
     super( e, calc, arity );
   }
 
+  // Marker under which an MDX NULL result is memorized: Caffeine cannot
+  // store null values, and re-evaluating NULL-valued tuples on every
+  // comparison would defeat the memoization. The marker never leaves this
+  // class; eval() unwraps it back to Java null.
+  private static final Object NULL_RESULT = new Object();
+
   // applies the Calc to a tuple, memorizing results
   protected Object eval( List<Member> key ) {
     if ( valueCache == null ) {
@@ -74,7 +79,8 @@ abstract class TupleExpMemoComparator extends TupleComparator.TupleExpComparator
     // Loader exceptions (e.g. CellRequestQuantumExceededException, which drives
     // the batch-reload protocol) propagate unwrapped: Caffeine does not wrap
     // them, unlike the former Guava cache.
-    return valueCache.get( key, this::evaluateCalc );
+    Object val = valueCache.get( key, this::evaluateCalc );
+    return val == NULL_RESULT ? null : val;
   }
 
   private List<Member> dependentMembers( List<Member> tuple ) {
@@ -117,7 +123,7 @@ public int compare( List<Member> a1, List<Member> a2 ) {
   private Object evaluateCalc( List<Member> tuple ) {
     evaluator.setContext( tuple );
     Object val = calc.evaluate( evaluator );
-    return val == null ? Util.nullValue : val;
+    return val == null ? NULL_RESULT : val;
   }
 
   static class BreakTupleComparator extends TupleExpMemoComparator {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/AggregateCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/AggregateCalc.java
@@ -90,7 +90,7 @@ public class AggregateCalc  extends AbstractProfilingNestedUnknownCalc {
      * @param evaluator Evaluation context
      * @param tupleList List of members or tuples
      * @return Aggregated result
-     */
+ */
     public static Object aggregate(
         Calc<?> calc,
         Evaluator evaluator,
@@ -129,7 +129,8 @@ public class AggregateCalc  extends AbstractProfilingNestedUnknownCalc {
         // All that follows is logic for distinct count. It's not like the
         // other aggregators.
         if (tupleList.isEmpty()) {
-            return FunUtil.DOUBLE_NULL;
+            // Aggregate({}) is NULL — Java null.
+            return null;
         }
 
         // Optimize the list
@@ -183,7 +184,7 @@ public class AggregateCalc  extends AbstractProfilingNestedUnknownCalc {
      * be safely optimized. If a member of the tuple list is on
      * a hierarchy for which a rollup policy of PARTIAL is set,
      * it is not safe to optimize that list.
-     */
+ */
     private static boolean canOptimize(
         Evaluator evaluator,
         TupleList tupleList)
@@ -247,7 +248,7 @@ public class AggregateCalc  extends AbstractProfilingNestedUnknownCalc {
      *  (Gender.[All Gender], [Product].[All Products])
      *
      * @param list List of tuples
-     */
+ */
     private static TupleList removeOverlappingTupleEntries(
         TupleList list)
     {
@@ -287,7 +288,7 @@ public class AggregateCalc  extends AbstractProfilingNestedUnknownCalc {
      * @param tuple1 First tuple
      * @param tuple2 Second tuple
      * @return boolean Whether tuple1 is a superset of tuple2
-     */
+ */
     public static boolean isSuperSet(Member[] tuple1, Member[] tuple2) {
         int parentLevelCount = 0;
         for (int i = 0; i < tuple1.length; i++) {
@@ -350,7 +351,7 @@ public class AggregateCalc  extends AbstractProfilingNestedUnknownCalc {
      * @param reader Schema reader
      * @param baseCubeForMeasure Cube
      * @return xxxx
-     */
+ */
     public static TupleList optimizeChildren(
         TupleList tuples,
         CatalogReader reader,
@@ -393,7 +394,7 @@ public class AggregateCalc  extends AbstractProfilingNestedUnknownCalc {
      *
      * @param tupleList List of tuples
      * @return Map of the number of occurrences of each member in a tuple
-     */
+ */
     public static Map<Member, Integer>[] membersVersusOccurencesInTuple(
         TupleList tupleList)
     {
@@ -489,7 +490,7 @@ public class AggregateCalc  extends AbstractProfilingNestedUnknownCalc {
      * @param tuple1 First tuple
      * @param tuple2 Second tuple
      * @return whether tuples are equal
-     */
+ */
     private static boolean isEqual(Member[] tuple1, Member[] tuple2) {
         for (int i = 0; i < tuple1.length; i++) {
             if (!tuple1[i].getUniqueName().equals(

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/acos/AcosCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/acos/AcosCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.acos;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class AcosCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class AcosCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (number == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         return Math.acos(number);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/acos/AcoshCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/acos/AcoshCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.acos;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class AcoshCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class AcoshCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double x = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (x == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(x)) {
             return null;
         }
         return Math.log(x + Math.sqrt((x * x) - 1.0));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.asin;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class AsinCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class AsinCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double x = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (x == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(x)) {
             return null;
         }
         return Math.asin(x);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinhCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinhCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.asin;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class AsinhCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class AsinhCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double x = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (x == FunUtil.DOUBLE_NULL || x == null) {
+        if (NullSemantics.isNull(x)) {
             return null;
         }
         return Math.log(x + Math.sqrt(1.0 + (x * x)));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/atan2/Atan2Calc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/atan2/Atan2Calc.java
@@ -28,6 +28,11 @@ public class Atan2Calc extends AbstractProfilingNestedDoubleCalc {
     public Double evaluateInternal(Evaluator evaluator) {
         Double x = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         Double y = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
+
+        if (x == null || y == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.atan2(y, x);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/atan2/AtanhCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/atan2/AtanhCalc.java
@@ -27,6 +27,11 @@ public class AtanhCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double x = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (x == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return .5 * Math.log((1.0 + x) / (1.0 - x));
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/cosh/CoshCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/cosh/CoshCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.cosh;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class CoshCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class CoshCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (number == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         return Math.cosh(number);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/degrees/DegreesCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/degrees/DegreesCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.degrees;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class DegreesCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class DegreesCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (number == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         // 180 degrees = Pi radians

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/log10/Log10Calc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/log10/Log10Calc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.log10;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class Log10Calc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class Log10Calc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (number == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         return Math.log10(number);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/power/PowerCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/power/PowerCalc.java
@@ -28,6 +28,11 @@ public class PowerCalc extends AbstractProfilingNestedDoubleCalc {
     public Double evaluateInternal(Evaluator evaluator) {
         Double x = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         Double y = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
+
+        if (x == null || y == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.pow(x, y);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/radians/RadiansCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/radians/RadiansCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.radians;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class RadiansCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class RadiansCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (number == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         // 180 degrees = Pi radians

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/sinh/SinhCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/sinh/SinhCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.sinh;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class SinhCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class SinhCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (number == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         return Math.sinh(number);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/sqrtpi/SqrtPiCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/sqrtpi/SqrtPiCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.sqrtpi;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class SqrtPiCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class SqrtPiCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (number == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         return Math.sqrt(number * Math.PI);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/tanh/TanhCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/tanh/TanhCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.excel.tanh;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class TanhCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class TanhCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (number == FunUtil.DOUBLE_NULL) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         return Math.tanh(number);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegCalc.java
@@ -51,7 +51,7 @@ public class LinRegCalc extends AbstractProfilingNestedDoubleCalc {
     public Double evaluateInternal(Evaluator evaluator) {
         Value value = process(evaluator, tupleListCalc, yCalc, xCalc);
         if (value == null) {
-            return FunUtil.DOUBLE_NULL;
+            return null;
         }
         switch (regType) {
         case LinRegFunDef.INTERCEPT:

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/PointCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/PointCalc.java
@@ -19,7 +19,6 @@ import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class PointCalc extends AbstractProfilingNestedDoubleCalc {
     private final DoubleCalc xPointCalc;
@@ -45,8 +44,8 @@ public class PointCalc extends AbstractProfilingNestedDoubleCalc {
     public Double evaluateInternal(Evaluator evaluator) {
         Double xPoint = xPointCalc.evaluate(evaluator);
         Value value = LinRegCalc.process(evaluator, tupleListCalc, yCalc, xCalc);
-        if (value == null) {
-            return FunUtil.DOUBLE_NULL;
+        if (value == null || xPoint == null) {
+            return null;
         }
         // use first arg to generate y position
         return xPoint * value.getSlope() + value.getIntercept();

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nonstandard/CastCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nonstandard/CastCalc.java
@@ -104,15 +104,16 @@ public class CastCalc extends AbstractProfilingNestedUnknownCalc {
         throw cannotConvert(o, targetType);
     }
 
-    private double toDouble(Object o, final Type targetType) {
+    private Double toDouble(Object o, final Type targetType) {
         if (o == null) {
-            return FunUtil.DOUBLE_NULL;
+            // Cast(NULL as Numeric) is NULL — Java null.
+            return null;
         }
         if (o instanceof Boolean bool) {
             if (Boolean.TRUE.equals(bool)) {
-                return 1;
+                return 1.0;
             } else {
-                return 0;
+                return 0.0;
             }
         }
         if (o instanceof String str) {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/divide/DivideCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/divide/DivideCalc.java
@@ -17,8 +17,8 @@ package org.eclipse.daanse.olap.function.def.operators.divide;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class DivideCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -43,19 +43,18 @@ public class DivideCalc extends AbstractProfilingNestedDoubleCalc {
         // Null. This is only used by certain applications and does not
         // conform to MSAS behavior.
         if (!nullDenominatorProducesNull) {
-            if (v0 == FunUtil.DOUBLE_NULL || v0 == null) {
-                return FunUtil.DOUBLE_NULL;
-            } else if (v1 == FunUtil.DOUBLE_NULL || v1 == null) {
+            if (NullSemantics.isNull(v0)) {
+                return null;
+            } else if (NullSemantics.isNull(v1)) {
                 // Null only in denominator returns Infinity.
                 return Double.POSITIVE_INFINITY;
             } else {
                 return v0 / v1;
             }
         } else {
-            // Null in numerator or denominator returns
-            // DoubleNull.
-            if (v0 == FunUtil.DOUBLE_NULL || v1 == FunUtil.DOUBLE_NULL || v0 == null || v1 == null) {
-                return FunUtil.DOUBLE_NULL;
+            // Null in numerator or denominator returns NULL (Java null).
+            if (NullSemantics.isNull(v0) || NullSemantics.isNull(v1)) {
+                return null;
             } else {
                 return v0 / v1;
             }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualCalc.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedBooleanCalc;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
@@ -32,7 +33,9 @@ public class EqualCalc extends AbstractProfilingNestedBooleanCalc {
     public Boolean evaluateInternal(Evaluator evaluator) {
         final Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
-        if (Double.isNaN(v0) || Double.isNaN(v1) || v0 == FunUtil.DOUBLE_NULL || v1 == FunUtil.DOUBLE_NULL) {
+        // Null check first: MDX NULL is Java null and Double.isNaN
+        // would throw on unboxing. NULL comparisons yield BOOLEAN_NULL (false).
+        if (NullSemantics.isNull(v0) || NullSemantics.isNull(v1) || Double.isNaN(v0) || Double.isNaN(v1)) {
             return FunUtil.BOOLEAN_NULL;
         }
         return Objects.equals(v0, v1);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterCalc.java
@@ -17,6 +17,7 @@ package org.eclipse.daanse.olap.function.def.operators.greater;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedBooleanCalc;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
@@ -30,7 +31,9 @@ public class GreaterCalc extends AbstractProfilingNestedBooleanCalc {
     public Boolean evaluateInternal(Evaluator evaluator) {
         final Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
-        if (Double.isNaN(v0) || Double.isNaN(v1) || v0 == FunUtil.DOUBLE_NULL || v1 == FunUtil.DOUBLE_NULL) {
+        // Null check first: MDX NULL is Java null and Double.isNaN
+        // would throw on unboxing. NULL comparisons yield BOOLEAN_NULL (false).
+        if (NullSemantics.isNull(v0) || NullSemantics.isNull(v1) || Double.isNaN(v0) || Double.isNaN(v1)) {
             return FunUtil.BOOLEAN_NULL;
         }
         return v0 > v1;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOrEqualCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOrEqualCalc.java
@@ -17,6 +17,7 @@ package org.eclipse.daanse.olap.function.def.operators.greater;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedBooleanCalc;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
@@ -30,7 +31,9 @@ public class GreaterOrEqualCalc extends AbstractProfilingNestedBooleanCalc {
     public Boolean evaluateInternal(Evaluator evaluator) {
         final Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
-        if (Double.isNaN(v0) || Double.isNaN(v1) || v0 == FunUtil.DOUBLE_NULL || v1 == FunUtil.DOUBLE_NULL) {
+        // Null check first: MDX NULL is Java null and Double.isNaN
+        // would throw on unboxing. NULL comparisons yield BOOLEAN_NULL (false).
+        if (NullSemantics.isNull(v0) || NullSemantics.isNull(v1) || Double.isNaN(v0) || Double.isNaN(v1)) {
             return FunUtil.BOOLEAN_NULL;
         }
         return v0 >= v1;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessCalc.java
@@ -17,6 +17,7 @@ package org.eclipse.daanse.olap.function.def.operators.less;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedBooleanCalc;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
@@ -30,7 +31,9 @@ public class LessCalc extends AbstractProfilingNestedBooleanCalc {
     public Boolean evaluateInternal(Evaluator evaluator) {
         final Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
-        if (Double.isNaN(v0) || Double.isNaN(v1) || v0 == FunUtil.DOUBLE_NULL || v1 == FunUtil.DOUBLE_NULL) {
+        // Null check first: MDX NULL is Java null and Double.isNaN
+        // would throw on unboxing. NULL comparisons yield BOOLEAN_NULL (false).
+        if (NullSemantics.isNull(v0) || NullSemantics.isNull(v1) || Double.isNaN(v0) || Double.isNaN(v1)) {
             return FunUtil.BOOLEAN_NULL;
         }
         return v0 < v1;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessOrEqualCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessOrEqualCalc.java
@@ -17,6 +17,7 @@ package org.eclipse.daanse.olap.function.def.operators.less;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedBooleanCalc;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
@@ -30,7 +31,9 @@ public class LessOrEqualCalc extends AbstractProfilingNestedBooleanCalc {
     public Boolean evaluateInternal(Evaluator evaluator) {
         final Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
-        if (Double.isNaN(v0) || Double.isNaN(v1) || v0 == FunUtil.DOUBLE_NULL || v1 == FunUtil.DOUBLE_NULL) {
+        // Null check first: MDX NULL is Java null and Double.isNaN
+        // would throw on unboxing. NULL comparisons yield BOOLEAN_NULL (false).
+        if (NullSemantics.isNull(v0) || NullSemantics.isNull(v1) || Double.isNaN(v0) || Double.isNaN(v1)) {
             return FunUtil.BOOLEAN_NULL;
         }
         return v0 <= v1;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusCalc.java
@@ -17,8 +17,8 @@ package org.eclipse.daanse.olap.function.def.operators.minus;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class MinusCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -30,14 +30,14 @@ public class MinusCalc extends AbstractProfilingNestedDoubleCalc {
     public Double evaluateInternal(Evaluator evaluator) {
         final Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
-        if (v0 == FunUtil.DOUBLE_NULL || v0 == null) {
-            if (v1 == FunUtil.DOUBLE_NULL || v1 == null) {
-                return FunUtil.DOUBLE_NULL;
+        if (NullSemantics.isNull(v0)) {
+            if (NullSemantics.isNull(v1)) {
+                return null;
             } else {
                 return -v1;
             }
         } else {
-            if (v1 == FunUtil.DOUBLE_NULL || v1 == null) {
+            if (NullSemantics.isNull(v1)) {
                 return v0;
             } else {
                 return v0 - v1;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusPrefixCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusPrefixCalc.java
@@ -17,8 +17,8 @@ package org.eclipse.daanse.olap.function.def.operators.minus;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class MinusPrefixCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -29,8 +29,8 @@ public class MinusPrefixCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         final Double v = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (v == FunUtil.DOUBLE_NULL || v == null) {
-            return FunUtil.DOUBLE_NULL;
+        if (NullSemantics.isNull(v)) {
+            return null;
         } else {
             return - v;
         }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/multiply/MultiplyCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/multiply/MultiplyCalc.java
@@ -17,8 +17,8 @@ package org.eclipse.daanse.olap.function.def.operators.multiply;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class MultiplyCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -32,8 +32,8 @@ public class MultiplyCalc extends AbstractProfilingNestedDoubleCalc {
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
         // Multiply and divide return null if EITHER arg is
         // null.
-        if (v0 == FunUtil.DOUBLE_NULL || v1 == FunUtil.DOUBLE_NULL || v0 == null|| v1 == null) {
-            return FunUtil.DOUBLE_NULL;
+        if (NullSemantics.isNull(v0) || NullSemantics.isNull(v1)) {
+            return null;
         } else {
             return v0 * v1;
         }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualCalc.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedBooleanCalc;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
@@ -32,7 +33,9 @@ public class NotEqualCalc extends AbstractProfilingNestedBooleanCalc {
     public Boolean evaluateInternal(Evaluator evaluator) {
         final Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
-        if (Double.isNaN(v0) || Double.isNaN(v1) || v0 == FunUtil.DOUBLE_NULL || v1 == FunUtil.DOUBLE_NULL) {
+        // Null check first: MDX NULL is Java null and Double.isNaN
+        // would throw on unboxing. NULL comparisons yield BOOLEAN_NULL (false).
+        if (NullSemantics.isNull(v0) || NullSemantics.isNull(v1) || Double.isNaN(v0) || Double.isNaN(v1)) {
             return FunUtil.BOOLEAN_NULL;
         }
         return !Objects.equals(v0, v1);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/plus/PlusCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/plus/PlusCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.operators.plus;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class PlusCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -30,14 +30,14 @@ public class PlusCalc extends AbstractProfilingNestedDoubleCalc {
         final Double v0 = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         final Double v1 = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
 
-        if (v0 == FunUtil.DOUBLE_NULL || v0 == null) {
-            if (v1 == FunUtil.DOUBLE_NULL || v1 == null) {
-                return FunUtil.DOUBLE_NULL;
+        if (NullSemantics.isNull(v0)) {
+            if (NullSemantics.isNull(v1)) {
+                return null;
             } else {
                 return v1;
             }
         } else {
-            if (v1 == FunUtil.DOUBLE_NULL || v1 == null) {
+            if (NullSemantics.isNull(v1)) {
                 return v0;
             } else {
                 return v0 + v1;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/percentile/PercentileCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/percentile/PercentileCalc.java
@@ -34,7 +34,12 @@ public class PercentileCalc extends AbstractProfilingNestedDoubleCalc{
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         TupleList list = AbstractAggregateFunDef.evaluateCurrentList(getChildCalc(0, TupleListCalc.class), evaluator);
-        Double percent = getChildCalc(2, DoubleCalc.class).evaluate(evaluator) * 0.01;
+        Double percentArg = getChildCalc(2, DoubleCalc.class).evaluate(evaluator);
+        if (percentArg == null) {
+            // A NULL percent argument yields NULL .
+            return null;
+        }
+        Double percent = percentArg * 0.01;
         final int savepoint = evaluator.savepoint();
         try {
             evaluator.setNonEmpty(false);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/percentile/PercentileFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/percentile/PercentileFunDef.java
@@ -41,7 +41,12 @@ public class PercentileFunDef extends AbstractAggregateFunDef {
             @Override
             public Double evaluateInternal(Evaluator evaluator) {
                 TupleList list = AbstractAggregateFunDef.evaluateCurrentList(tupleListCalc, evaluator);
-                Double percent = percentCalc.evaluate(evaluator) * 0.01;
+                Double percentArg = percentCalc.evaluate(evaluator);
+                if (percentArg == null) {
+                    // A NULL percent argument yields NULL .
+                    return null;
+                }
+                Double percent = percentArg * 0.01;
                 final int savepoint = evaluator.savepoint();
                 try {
                     evaluator.setNonEmpty(false);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/Rank3MemberCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/Rank3MemberCalc.java
@@ -22,8 +22,8 @@ import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedIntegerCalc;
-import org.eclipse.daanse.olap.common.Util;
 
 public class Rank3MemberCalc extends AbstractProfilingNestedIntegerCalc {
     private final ExpCacheDescriptor cacheDescriptor;
@@ -77,7 +77,7 @@ public class Rank3MemberCalc extends AbstractProfilingNestedIntegerCalc {
         }
 
         // If value is null, it won't be in the values array.
-        if ( value == Util.nullValue || value == null ) {
+        if ( NullSemantics.isNull(value) ) {
           return sortResult.values.length + 1;
         }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/Rank3TupleCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/Rank3TupleCalc.java
@@ -22,8 +22,8 @@ import org.eclipse.daanse.olap.api.calc.TupleCalc;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedIntegerCalc;
-import org.eclipse.daanse.olap.common.Util;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class Rank3TupleCalc extends AbstractProfilingNestedIntegerCalc {
@@ -86,7 +86,7 @@ public class Rank3TupleCalc extends AbstractProfilingNestedIntegerCalc {
         }
 
         // If value is null, it won't be in the values array.
-        if ( value == Util.nullValue || value == null ) {
+        if ( NullSemantics.isNull(value) ) {
           return sortResult.values.length + 1;
         }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/RankFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/RankFunDef.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.daanse.olap.function.def.rank;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.TupleCalc;
@@ -99,7 +100,7 @@ public class RankFunDef extends AbstractFunctionDefinition {
     }
 
     static boolean valueNotReady( Object value ) {
-      return value == Util.valueNotReadyException || value == Double.valueOf( Double.NaN );
+      return value == NotLoaded.INSTANCE || value == Double.valueOf( Double.NaN );
     }
 
   }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/SortedListCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/SortedListCalc.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleList;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
@@ -44,7 +45,7 @@ public class SortedListCalc extends AbstractProfilingNestedCalc {
      *          Compiled expression to compute the list
      * @param keyCalc
      *          Compiled expression to compute the sort key
-     */
+ */
     public SortedListCalc( Type type, TupleListCalc tupleListCalc, Calc keyCalc ) {
       super( type, tupleListCalc, keyCalc );
       this.tupleListCalc = tupleListCalc;
@@ -91,8 +92,10 @@ public class SortedListCalc extends AbstractProfilingNestedCalc {
               if ( exception == null ) {
                 exception = runtimeException;
               }
-            } else if ( Util.isNull( keyValue ) ) {
-              // nothing to do
+            } else if ( Util.isNull( keyValue ) || keyValue == NotLoaded.INSTANCE ) {
+              // NULL: nothing to do. NotLoaded: dirty batching pass whose
+              // ranks are discarded - skip instead of choking on the
+              // non-Comparable marker (the legacy Double(0) sorted silently).
             } else {
               // Assume it's the first time seeing this keyValue.
               Integer valueCounter = uniqueValueCounterMap.put( keyValue, SortedListCalc.ONE );
@@ -115,8 +118,10 @@ public class SortedListCalc extends AbstractProfilingNestedCalc {
               if ( exception == null ) {
                 exception = runtimeException;
               }
-            } else if ( Util.isNull( keyValue ) ) {
-              // nothing to do
+            } else if ( Util.isNull( keyValue ) || keyValue == NotLoaded.INSTANCE ) {
+              // NULL: nothing to do. NotLoaded: dirty batching pass whose
+              // ranks are discarded - skip instead of choking on the
+              // non-Comparable marker (the legacy Double(0) sorted silently).
             } else {
               // Assume it's the first time seeing this keyValue.
               Integer valueCounter = uniqueValueCounterMap.put( keyValue, SortedListCalc.ONE );

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/TopBottomPercentSumCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/TopBottomPercentSumCalc.java
@@ -16,6 +16,7 @@ package org.eclipse.daanse.olap.function.def.topbottompercentsum;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleList;
@@ -24,6 +25,7 @@ import org.eclipse.daanse.olap.api.element.Hierarchy;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.type.tuplebase.AbstractProfilingNestedTupleListCalc;
 import org.eclipse.daanse.olap.calc.base.util.HierarchyDependsChecker;
 import org.eclipse.daanse.olap.common.Util;
@@ -51,6 +53,10 @@ public class TopBottomPercentSumCalc extends AbstractProfilingNestedTupleListCal
         if (list.isEmpty()) {
             return list;
         }
+        if (target == null) {
+            // A NULL target behaves like 0 .
+            target = 0.0;
+        }
         Map<List<Member>, Object> mapMemberToValue = Sorter.evaluateTuples(evaluator, calc, list);
         final int savepoint = evaluator.savepoint();
         try {
@@ -72,10 +78,13 @@ public class TopBottomPercentSumCalc extends AbstractProfilingNestedTupleListCal
             }
             final List<Member> key = list.get(i);
             final Object o = mapMemberToValue.get(key);
-            if (o == Util.nullValue) {
+            if (NullSemantics.isNull(o)) {
                 nullCount++;
             } else if (o instanceof Number n) {
                 runningTotal += n.doubleValue();
+            } else if (o == NotLoaded.INSTANCE) {
+                // dirty batching pass, results discarded - the legacy
+                // Double(0) marker used to add 0 to the running total here
             } else if (o instanceof Exception) {
                 // ignore the error
             } else {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/lastnonempty/LastNonEmptyCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/lastnonempty/LastNonEmptyCalc.java
@@ -15,6 +15,7 @@ package org.eclipse.daanse.olap.function.def.udf.lastnonempty;
 
 import java.util.List;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleList;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
@@ -67,7 +68,7 @@ public class LastNonEmptyCalc extends AbstractProfilingNestedMemberCalc {
                     continue;
                 }
             }
-            if (o == Util.valueNotReadyException) {
+            if (o == NotLoaded.INSTANCE) {
                 // Value is not in the cache yet, so we don't know whether
                 // it will be empty. Carry on...
                 continue;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/nullvalue/NullValueCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/nullvalue/NullValueCalc.java
@@ -16,7 +16,6 @@ package org.eclipse.daanse.olap.function.def.udf.nullvalue;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.type.Type;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.common.Util;
 
 public class NullValueCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -26,7 +25,8 @@ public class NullValueCalc extends AbstractProfilingNestedDoubleCalc {
 
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
-        return Util.DOUBLE_NULL;
+        // MDX NULL is Java null in the Double calc world since .
+        return null;
     }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/abs/AbsCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/abs/AbsCalc.java
@@ -27,6 +27,11 @@ public class AbsCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (number == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.abs(number);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/atn/AtnCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/atn/AtnCalc.java
@@ -27,6 +27,11 @@ public class AtnCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (number == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.atan(number);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cdbl/CDblCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cdbl/CDblCalc.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.daanse.olap.function.def.vba.cdbl;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.type.Type;
@@ -27,6 +28,15 @@ public class CDblCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Object expression = getChildCalc(0, Calc.class).evaluate(evaluator);
+        if (expression == null) {
+            // MDX NULL stays NULL: the legacy sentinel passed through the
+            // Number branch unchanged, i.e. remained NULL downstream.
+            return null;
+        }
+        if (expression == NotLoaded.INSTANCE) {
+            // discarded dirty-pass marker; legacy Double(0) yielded 0.0
+            return 0.0;
+        }
         if (expression instanceof Number number) {
             return number.doubleValue();
         } else {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cint/CIntCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cint/CIntCalc.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.daanse.olap.function.def.vba.cint;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.type.Type;
@@ -31,6 +32,12 @@ public class CIntCalc extends AbstractProfilingNestedIntegerCalc {
     }
 
     public static int cInt(Object expression) {
+        if (expression == null || expression == NotLoaded.INSTANCE) {
+            // MDX NULL coerces to 0; NotLoaded is the marker of the dirty
+            // evaluation pass, whose results are discarded, so 0 is a safe
+            // dummy there as well.
+            return 0;
+        }
         if (expression instanceof Number number) {
             final int intValue = number.intValue();
             if (number instanceof Float || number instanceof Double) {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cos/CosCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cos/CosCalc.java
@@ -27,6 +27,11 @@ public class CosCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (number == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.cos(number);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/dateadd/DateAddCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/dateadd/DateAddCalc.java
@@ -39,6 +39,11 @@ public class DateAddCalc extends AbstractProfilingNestedDateTimeCalc {
         Double number = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
         LocalDateTime dateTime = getChildCalc(2, DateTimeCalc.class).evaluate(evaluator);
 
+        if (intervalName == null || number == null || dateTime == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
+
         Interval interval = Interval.valueOf(intervalName);
         final double floor = Math.floor(number);
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ddb/DDBCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ddb/DDBCalc.java
@@ -30,6 +30,11 @@ public class DDBCalc extends AbstractProfilingNestedDoubleCalc {
         Double life = getChildCalc(2, DoubleCalc.class).evaluate(evaluator);
         Double period = getChildCalc(3, DoubleCalc.class).evaluate(evaluator);
         Double factor = getChildCalc(4, DoubleCalc.class).evaluate(evaluator);
+
+        if (cost == null || salvage == null || life == null || period == null || factor == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return (((cost - salvage) * factor) / life) * period;
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/exp/ExpCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/exp/ExpCalc.java
@@ -16,8 +16,8 @@ package org.eclipse.daanse.olap.function.def.vba.exp;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedDoubleCalc;
-import org.eclipse.daanse.olap.common.Util;
 
 public class ExpCalc extends AbstractProfilingNestedDoubleCalc {
 
@@ -28,7 +28,7 @@ public class ExpCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
-        if (Util.DOUBLE_NULL.equals(number)) {
+        if (NullSemantics.isNull(number)) {
             return null;
         }
         return Math.exp(number);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/fv/FVCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/fv/FVCalc.java
@@ -33,6 +33,11 @@ public class FVCalc extends AbstractProfilingNestedDoubleCalc {
         Double pv = getChildCalc(3, DoubleCalc.class).evaluate(evaluator);
         Boolean type = getChildCalc(4, BooleanCalc.class).evaluate(evaluator);
 
+        if (rate == null || nPer == null || pmt == null || pv == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
+
         return fV(rate, nPer, pmt, pv, type);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/integer/IntCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/integer/IntCalc.java
@@ -18,6 +18,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.type.Type;
@@ -33,6 +34,11 @@ public class IntCalc extends AbstractProfilingNestedIntegerCalc {
     @Override
     public Integer evaluateInternal(Evaluator evaluator) {
         Object number = getChildCalc(0, Calc.class).evaluate(evaluator);
+        if (number == null || number == NotLoaded.INSTANCE) {
+            // legacy sentinel rounded to 0; NotLoaded is the discarded
+            // dirty-pass marker
+            return 0;
+        }
         if (number instanceof Number num) {
             int v = num.intValue();
             double dv = num.doubleValue();

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ipmt/IPmtCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ipmt/IPmtCalc.java
@@ -35,6 +35,11 @@ public class IPmtCalc extends AbstractProfilingNestedDoubleCalc {
         Double fv = getChildCalc(4, DoubleCalc.class).evaluate(evaluator);
         Boolean due = getChildCalc(5, BooleanCalc.class).evaluate(evaluator);
 
+        if (rate == null || per == null || nPer == null || pv == null || fv == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
+
         return iPmt(rate, per, nPer, pv, fv, due);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/irr/IRRCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/irr/IRRCalc.java
@@ -28,6 +28,11 @@ public class IRRCalc extends AbstractProfilingNestedDoubleCalc {
     public Double evaluateInternal(Evaluator evaluator) {
         Double[] valueArray = (Double[]) getChildCalc(0).evaluate(evaluator);
         Double guess = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
+
+        if (valueArray == null || guess == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         
 
         return irr(valueArray, guess);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/log/LogCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/log/LogCalc.java
@@ -27,6 +27,11 @@ public class LogCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (number == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.log(number);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/mirr/MIRRCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/mirr/MIRRCalc.java
@@ -30,6 +30,11 @@ public class MIRRCalc extends AbstractProfilingNestedDoubleCalc {
         Double[] valueArray = (Double[]) getChildCalc(0).evaluate(evaluator);
         Double financeRate = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
         Double reinvestRate = getChildCalc(2, DoubleCalc.class).evaluate(evaluator);
+
+        if (valueArray == null || financeRate == null || reinvestRate == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return mirr(valueArray, financeRate, reinvestRate);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/nper/NPerCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/nper/NPerCalc.java
@@ -32,6 +32,11 @@ public class NPerCalc extends AbstractProfilingNestedDoubleCalc {
         Double pv = getChildCalc(2, DoubleCalc.class).evaluate(evaluator);
         Double fv = getChildCalc(3, DoubleCalc.class).evaluate(evaluator);
         Boolean due = getChildCalc(3, BooleanCalc.class).evaluate(evaluator);
+
+        if (rate == null || pmt == null || pv == null || fv == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         
         if (rate == 0) {
             return -(fv + pv) / pmt;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/npv/NPVCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/npv/NPVCalc.java
@@ -29,6 +29,11 @@ public class NPVCalc extends AbstractProfilingNestedDoubleCalc {
     public Double evaluateInternal(Evaluator evaluator) {
         Double r = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         Double[] cfs = (Double[]) getChildCalc(1).evaluate(evaluator);
+
+        if (r == null || cfs == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return nPV(r, cfs);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/pmt/PmtCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/pmt/PmtCalc.java
@@ -32,6 +32,11 @@ public class PmtCalc extends AbstractProfilingNestedDoubleCalc {
         Double pv = getChildCalc(2, DoubleCalc.class).evaluate(evaluator);
         Double fv = getChildCalc(3, DoubleCalc.class).evaluate(evaluator);
         Boolean due = getChildCalc(4, BooleanCalc.class).evaluate(evaluator);
+
+        if (rate == null || nPer == null || pv == null || fv == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         
         return pmt(rate, nPer, pv, fv, due);
     }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ppmt/PPmtCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ppmt/PPmtCalc.java
@@ -35,6 +35,11 @@ public class PPmtCalc extends AbstractProfilingNestedDoubleCalc {
         Double fv = getChildCalc(4, DoubleCalc.class).evaluate(evaluator);
         Boolean due = getChildCalc(5, BooleanCalc.class).evaluate(evaluator);
 
+        if (rate == null || per == null || nPer == null || pv == null || fv == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
+
         return pmt(rate, nPer, pv, fv, due)
                 - iPmt(rate, per, nPer, pv, fv, due);
     }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/pv/PVCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/pv/PVCalc.java
@@ -32,6 +32,11 @@ public class PVCalc extends AbstractProfilingNestedDoubleCalc {
         Double pmt = getChildCalc(2, DoubleCalc.class).evaluate(evaluator);
         Double fv = getChildCalc(3, DoubleCalc.class).evaluate(evaluator);
         Boolean due = getChildCalc(4, BooleanCalc.class).evaluate(evaluator);
+
+        if (rate == null || nPer == null || pmt == null || fv == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return pV(rate, nPer, pmt, fv, due);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/rate/RateCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/rate/RateCalc.java
@@ -36,6 +36,11 @@ public class RateCalc extends AbstractProfilingNestedDoubleCalc {
         Boolean type = getChildCalc(4, BooleanCalc.class).evaluate(evaluator);
         Double guess = getChildCalc(5, DoubleCalc.class).evaluate(evaluator);
 
+        if (nPer == null || pmt == null || pv == null || fv == null || guess == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
+
         return rate(nPer, pmt, pv, fv, type, guess);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/round/RoundCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/round/RoundCalc.java
@@ -29,6 +29,11 @@ public class RoundCalc extends AbstractProfilingNestedDoubleCalc {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
         Integer numDigitsAfterDecimal = getChildCalc(1, IntegerCalc.class).evaluate(evaluator);
 
+        if (number == null || numDigitsAfterDecimal == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
+
         if (numDigitsAfterDecimal == 0) {
             return (double) Math.round(number);
         }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sgn/SgnCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sgn/SgnCalc.java
@@ -27,6 +27,11 @@ public class SgnCalc extends AbstractProfilingNestedIntegerCalc {
     @Override
     public Integer evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (number == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         // We could use Math.signum(double) from JDK 1.5 onwards.
         if (number < 0.0d) {
             return -1;

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sin/SinCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sin/SinCalc.java
@@ -27,6 +27,11 @@ public class SinCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (number == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.sin(number);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sln/SLNCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sln/SLNCalc.java
@@ -30,6 +30,11 @@ public class SLNCalc extends AbstractProfilingNestedDoubleCalc {
         Double salvage = getChildCalc(1, DoubleCalc.class).evaluate(evaluator);
         Double life = getChildCalc(2, DoubleCalc.class).evaluate(evaluator);
 
+        if (cost == null || salvage == null || life == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
+
         return (cost - salvage) / life;
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sqr/SqrCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sqr/SqrCalc.java
@@ -27,6 +27,11 @@ public class SqrCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (number == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.sqrt(number);
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/syd/SYDCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/syd/SYDCalc.java
@@ -31,6 +31,11 @@ public class SYDCalc extends AbstractProfilingNestedDoubleCalc {
         Double life = getChildCalc(2, DoubleCalc.class).evaluate(evaluator);
         Double period = getChildCalc(3, DoubleCalc.class).evaluate(evaluator);
 
+        if (cost == null || salvage == null || life == null || period == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
+
         return (cost - salvage) * (life / (period * (period + 1) / 2));
     }
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/tan/TanCalc.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/tan/TanCalc.java
@@ -27,6 +27,11 @@ public class TanCalc extends AbstractProfilingNestedDoubleCalc {
     @Override
     public Double evaluateInternal(Evaluator evaluator) {
         Double number = getChildCalc(0, DoubleCalc.class).evaluate(evaluator);
+
+        if (number == null) {
+            // A NULL operand yields NULL; guard before unboxing.
+            return null;
+        }
         return Math.tan(number);
     }
 

--- a/common/src/test/java/org/eclipse/daanse/olap/fun/SortTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/fun/SortTest.java
@@ -41,7 +41,7 @@ class SortTest {
 
   /**
    * Access properties via this object and their values will be reset.
-   */
+ */
 
   @AfterEach
   public void afterEach() {
@@ -54,12 +54,15 @@ class SortTest {
     // order. For example, NaN compares greater than
     // Double.NEGATIVE_INFINITY, -34.5, -0.001, 0, 0.00000567, 1, 3.14;
     // equal to NaN; and less than Double.POSITIVE_INFINITY.
+    //
+    // The unboxed order has no NULL slot: a primitive double cannot carry
+    // MDX NULL, so every value — however tiny — sorts numerically.
     double[] values = {
       Double.NEGATIVE_INFINITY,
-      FunUtil.DOUBLE_NULL,
       -34.5,
       -0.001,
       0,
+      1.25e-8,
       0.00000567,
       1,
       3.14,

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/acos/AcosCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/acos/AcosCalcTest.java
@@ -87,7 +87,7 @@ class AcosCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = acosCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/acos/AcoshCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/acos/AcoshCalcTest.java
@@ -96,7 +96,7 @@ class AcoshCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = acoshCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinCalcTest.java
@@ -88,7 +88,7 @@ class AsinCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = asinCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinhCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinhCalcTest.java
@@ -80,7 +80,7 @@ class AsinhCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = asinhCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/cosh/CoshCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/cosh/CoshCalcTest.java
@@ -99,7 +99,7 @@ class CoshCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = coshCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/degrees/DegreesCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/degrees/DegreesCalcTest.java
@@ -103,7 +103,7 @@ class DegreesCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = degreesCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/radians/RadiansCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/radians/RadiansCalcTest.java
@@ -103,7 +103,7 @@ class RadiansCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = radiansCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/sinh/SinhCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/sinh/SinhCalcTest.java
@@ -99,7 +99,7 @@ class SinhCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = sinhCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/sqrtpi/SqrtPiCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/sqrtpi/SqrtPiCalcTest.java
@@ -96,7 +96,7 @@ class SqrtPiCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = sqrtPiCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/tanh/TanhCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/excel/tanh/TanhCalcTest.java
@@ -120,7 +120,7 @@ class TanhCalcTest {
     @Test
     @DisplayName("Should return null for null input")
     void shouldReturnNullForNullInput() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(FunUtil.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = tanhCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/exp/ExpCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/exp/ExpCalcTest.java
@@ -70,7 +70,7 @@ class ExpCalcTest {
     @Test
     @DisplayName("Should return null for null value")
     void shouldReturnNullForNullValue() {
-        when(doubleCalc.evaluate(evaluator)).thenReturn(Util.DOUBLE_NULL);
+        when(doubleCalc.evaluate(evaluator)).thenReturn((Double) null);
 
         Double result = expCalc.evaluate(evaluator);
 

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/integer/IntCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/integer/IntCalcTest.java
@@ -67,12 +67,13 @@ class IntCalcTest {
 
     @Test
     @DisplayName("Should throw InvalidArgumentException for null input")
-    void shouldThrowExceptionForNullInput() {
+    void shouldCoerceNullInputToZero() {
+        // MDX NULL is Java null since the null-semantics migration; Int
+        // coerces it to 0, matching the legacy sentinel's observable
+        // behavior (.
         when(numberCalc.evaluate(evaluator)).thenReturn(null);
 
-        assertThatThrownBy(() -> intCalc.evaluate(evaluator)).isInstanceOf(InvalidArgumentException.class)
-                .hasMessageContaining("Invalid parameter")
-                .hasMessageContaining("number parameter null of Int function must be of type number");
+        assertThat(intCalc.evaluate(evaluator)).isEqualTo(0);
     }
 
     static Stream<Arguments> arguments() {

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/npv/NPVCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/npv/NPVCalcTest.java
@@ -75,21 +75,21 @@ class NPVCalcTest {
     }
 
     @Test
-    @DisplayName("Should handle null rate")
+    @DisplayName("Should return null for null rate")
     void shouldHandleNullRate() {
         when(rateCalc.evaluate(evaluator)).thenReturn(null);
         when(cashFlowsCalc.evaluate(evaluator)).thenReturn(new Double[] { -1000.0, 1100.0 });
 
-        assertThatThrownBy(() -> npvCalc.evaluate(evaluator)).isInstanceOf(NullPointerException.class);
+        assertThat(npvCalc.evaluate(evaluator)).isNull();
     }
 
     @Test
-    @DisplayName("Should handle null cash flows")
+    @DisplayName("Should return null for null cash flows")
     void shouldHandleNullCashFlows() {
         when(rateCalc.evaluate(evaluator)).thenReturn(0.10);
         when(cashFlowsCalc.evaluate(evaluator)).thenReturn(null);
 
-        assertThatThrownBy(() -> npvCalc.evaluate(evaluator)).isInstanceOf(NullPointerException.class);
+        assertThat(npvCalc.evaluate(evaluator)).isNull();
     }
 
     @Test

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/pmt/PmtCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/pmt/PmtCalcTest.java
@@ -129,7 +129,7 @@ class PmtCalcTest {
     }
 
     @Test
-    @DisplayName("Should handle null values")
+    @DisplayName("Should return null for null values")
     void shouldHandleNullValues() {
         when(rateCalc.evaluate(evaluator)).thenReturn(null);
         when(nPerCalc.evaluate(evaluator)).thenReturn(12.0);
@@ -137,7 +137,7 @@ class PmtCalcTest {
         when(fvCalc.evaluate(evaluator)).thenReturn(0.0);
         when(dueCalc.evaluate(evaluator)).thenReturn(false);
 
-        assertThatThrownBy(() -> pmtCalc.evaluate(evaluator)).isInstanceOf(NullPointerException.class);
+        assertThat(pmtCalc.evaluate(evaluator)).isNull();
     }
 
     @Test

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/pv/PVCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/pv/PVCalcTest.java
@@ -143,7 +143,7 @@ class PVCalcTest {
     }
 
     @Test
-    @DisplayName("Should handle null values")
+    @DisplayName("Should return null for null values")
     void shouldHandleNullValues() {
         when(rateCalc.evaluate(evaluator)).thenReturn(null);
         when(nPerCalc.evaluate(evaluator)).thenReturn(10.0);
@@ -151,7 +151,7 @@ class PVCalcTest {
         when(fvCalc.evaluate(evaluator)).thenReturn(0.0);
         when(dueCalc.evaluate(evaluator)).thenReturn(false);
 
-        assertThatThrownBy(() -> pvCalc.evaluate(evaluator)).isInstanceOf(NullPointerException.class);
+        assertThat(pvCalc.evaluate(evaluator)).isNull();
     }
 
     @Test

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/sln/SLNCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/sln/SLNCalcTest.java
@@ -125,13 +125,13 @@ class SLNCalcTest {
     }
 
     @Test
-    @DisplayName("Should handle null values")
+    @DisplayName("Should return null for null values")
     void shouldHandleNullValues() {
         when(costCalc.evaluate(evaluator)).thenReturn(null);
         when(salvageCalc.evaluate(evaluator)).thenReturn(1000.0);
         when(lifeCalc.evaluate(evaluator)).thenReturn(5.0);
 
-        assertThatThrownBy(() -> slnCalc.evaluate(evaluator)).isInstanceOf(NullPointerException.class);
+        assertThat(slnCalc.evaluate(evaluator)).isNull();
     }
 
     @Test

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/AggregateNullSemanticsTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/AggregateNullSemanticsTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.daanse.olap.api.calc.Calc;
+import org.eclipse.daanse.olap.api.calc.tuple.TupleList;
+import org.eclipse.daanse.olap.api.element.Member;
+import org.eclipse.daanse.olap.api.evaluator.Evaluator;
+import org.eclipse.daanse.olap.api.execution.Execution;
+import org.eclipse.daanse.olap.api.execution.Statement;
+import org.eclipse.daanse.olap.api.query.component.Query;
+import org.eclipse.daanse.olap.api.result.NotLoaded;
+import org.eclipse.daanse.olap.api.type.NumericType;
+import org.eclipse.daanse.olap.calc.base.type.tuplebase.UnaryTupleList;
+import org.eclipse.daanse.olap.fun.FunUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * NULL semantics of the static aggregate helpers in {@code FunUtil}:
+ *
+ * <ul>
+ * <li>Empty sets: sum/sumDouble/min/max/avg/percentile/quartile return Java
+ * {@code null} (MDX NULL).</li>
+ * <li>NULL cells (Java {@code null}) are skipped by evaluateSet, so
+ * aggregates ignore them — including the divisor of avg.</li>
+ * <li>Error cells ({@link NotLoaded}) turn the aggregate into NaN.</li>
+ * </ul>
+ */
+class AggregateNullSemanticsTest {
+
+    private Evaluator evaluator;
+    private Calc<Object> exp;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        evaluator = mock(Evaluator.class);
+
+        // FunUtil.evaluateSet reaches for
+        // evaluator.getQuery().getStatement().getCurrentExecution().
+        Query query = mock(Query.class);
+        Statement statement = mock(Statement.class);
+        Execution execution = mock(Execution.class);
+        when(evaluator.getQuery()).thenReturn(query);
+        when(query.getStatement()).thenReturn(statement);
+        when(statement.getCurrentExecution()).thenReturn(execution);
+
+        exp = mock(Calc.class);
+        when(exp.getType()).thenReturn(NumericType.INSTANCE);
+    }
+
+    private static TupleList tuples(int memberCount) {
+        List<Member> members = new ArrayList<>();
+        for (int i = 0; i < memberCount; i++) {
+            members.add(mock(Member.class));
+        }
+        return new UnaryTupleList(members);
+    }
+
+    private void stubCellValues(Object first, Object... rest) {
+        when(exp.evaluate(evaluator)).thenReturn(first, rest);
+    }
+
+    // --- sumDouble / sum ---------------------------------------------------
+
+    @Test
+    @DisplayName("sumDouble of an empty set returns Java null")
+    void sumDoubleOfEmptySetReturnsJavaNull() {
+        Double result = FunUtil.sumDouble(evaluator, tuples(0), exp);
+
+        // Sum({}) = NULL — Java null, distinguishable from any
+        // genuine sum.
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("sumDouble skips NULL cells")
+    void sumDoubleIgnoresNullCells(){
+        stubCellValues(5.0, null, 3.0);
+
+        Double result = FunUtil.sumDouble(evaluator, tuples(3), exp);
+
+        assertThat(result).isEqualTo(8.0);
+    }
+
+    @Test
+    @DisplayName("sumDouble returns NaN when a cell holds NotLoaded (error)")
+    void sumDoubleWithErrorCellReturnsNaN() {
+        stubCellValues(5.0, NotLoaded.INSTANCE, 3.0);
+
+        Double result = FunUtil.sumDouble(evaluator, tuples(3), exp);
+
+        assertThat(result).isNaN();
+    }
+
+    @Test
+    @DisplayName("sum of an empty set returns Java null ")
+    void sumOfEmptySetReturnsNull() {
+        Object result = FunUtil.sum(evaluator, tuples(0), exp);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("sum of real values returns their boxed sum")
+    void sumOfRealValues() {
+        stubCellValues(2.0, 3.0);
+
+        Object result = FunUtil.sum(evaluator, tuples(2), exp);
+
+        assertThat(result).isEqualTo(5.0);
+    }
+
+    // --- percentile / quartile ----------------------------------------------
+
+    @Test
+    @DisplayName("percentile of an empty set returns Java null")
+    void percentileOfEmptySetReturnsJavaNull() {
+        Double result = FunUtil.percentile(evaluator, tuples(0), exp, 0.5);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("percentile (median) of real values, NULL cells skipped")
+    void percentileMedianIgnoresNullCells() {
+        stubCellValues(3.0, null, 1.0, 2.0);
+
+        Double result = FunUtil.percentile(evaluator, tuples(4), exp, 0.5);
+
+        assertThat(result).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("quartile of an empty set returns Java null")
+    void quartileOfEmptySetReturnsJavaNull() {
+        Double result = FunUtil.quartile(evaluator, tuples(0), exp, 2);
+
+        assertThat(result).isNull();
+    }
+
+    // --- min / max / avg -----------------------------------------------------
+
+    @Test
+    @DisplayName("min of an empty set returns Java null")
+    void minOfEmptySetReturnsNull() {
+        Object result = FunUtil.min(evaluator, tuples(0), exp);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("max of an empty set returns Java null")
+    void maxOfEmptySetReturnsNull() {
+        Object result = FunUtil.max(evaluator, tuples(0), exp);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("min/max of real values with NULL cells skipped")
+    void minMaxIgnoreNullCells() {
+        stubCellValues(3.0, null, 1.0, 2.0);
+        assertThat(FunUtil.min(evaluator, tuples(4), exp)).isEqualTo(1.0);
+
+        stubCellValues(3.0, null, 1.0, 2.0);
+        assertThat(FunUtil.max(evaluator, tuples(4), exp)).isEqualTo(3.0);
+    }
+
+    @Test
+    @DisplayName("avg of an empty set returns Java null")
+    void avgOfEmptySetReturnsNull() {
+        Object result = FunUtil.avg(evaluator, tuples(0), exp);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("avg ignores NULL cells (they do not count into the divisor)")
+    void avgIgnoresNullCells() {
+        stubCellValues(2.0, null, 4.0);
+
+        Object result = FunUtil.avg(evaluator, tuples(3), exp);
+
+        assertThat(result).isEqualTo(3.0);
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/CoercionNullSemanticsTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/CoercionNullSemanticsTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.daanse.olap.api.calc.Calc;
+import org.eclipse.daanse.olap.api.calc.DoubleCalc;
+import org.eclipse.daanse.olap.api.calc.IntegerCalc;
+import org.eclipse.daanse.olap.api.evaluator.Evaluator;
+import org.eclipse.daanse.olap.api.type.BooleanType;
+import org.eclipse.daanse.olap.api.type.NumericType;
+import org.eclipse.daanse.olap.calc.base.type.booleanx.DoubleToBooleanCalc;
+import org.eclipse.daanse.olap.calc.base.type.doublex.IntegerToDoubleCalc;
+import org.eclipse.daanse.olap.calc.base.type.doublex.UnknownToDoubleCalc;
+import org.eclipse.daanse.olap.fun.FunUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MDX NULL semantics of the type-coercion calcs (MDX NULL is Java
+ * {@code null} throughout the calc layer):
+ *
+ * <ul>
+ * <li>DoubleToBooleanCalc: Java null and NaN map to BOOLEAN_NULL, which is
+ * the primitive false (no 3VL).</li>
+ * <li>UnknownToDoubleCalc: Java null input produces Java null.</li>
+ * <li>IntegerToDoubleCalc: Java null input produces Java null.</li>
+ * </ul>
+ */
+class CoercionNullSemanticsTest {
+
+    private Evaluator evaluator;
+
+    @BeforeEach
+    void setUp() {
+        evaluator = mock(Evaluator.class);
+    }
+
+    @Nested
+    @DisplayName("DoubleToBooleanCalc: Java-null NULL check ")
+    class DoubleToBooleanCharacterization {
+
+        private DoubleCalc doubleCalc;
+        private DoubleToBooleanCalc calc;
+
+        @BeforeEach
+        void setUpCalc() {
+            doubleCalc = mock(DoubleCalc.class);
+            calc = new DoubleToBooleanCalc(BooleanType.INSTANCE, doubleCalc);
+        }
+
+        @Test
+        @DisplayName("Java null maps to BOOLEAN_NULL, which is false")
+        void javaNullMapsToBooleanNull() {
+            when(doubleCalc.evaluate(evaluator)).thenReturn(null);
+            // FunUtil.BOOLEAN_NULL is the primitive false — no 3VL: a NULL
+            // boolean is indistinguishable from a genuine FALSE.
+            assertThat(calc.evaluate(evaluator)).isEqualTo(FunUtil.BOOLEAN_NULL).isFalse();
+        }
+
+        @Test
+        @DisplayName("NaN maps to BOOLEAN_NULL, which is false")
+        void nanMapsToBooleanNull() {
+            when(doubleCalc.evaluate(evaluator)).thenReturn(Double.NaN);
+            assertThat(calc.evaluate(evaluator)).isFalse();
+        }
+
+        @Test
+        @DisplayName("zero maps to false, non-zero maps to true")
+        void realValues() {
+            when(doubleCalc.evaluate(evaluator)).thenReturn(0.0);
+            assertThat(calc.evaluate(evaluator)).isFalse();
+
+            when(doubleCalc.evaluate(evaluator)).thenReturn(2.0);
+            assertThat(calc.evaluate(evaluator)).isTrue();
+
+            when(doubleCalc.evaluate(evaluator)).thenReturn(-2.0);
+            assertThat(calc.evaluate(evaluator)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("UnknownToDoubleCalc: NULL inputs map to Java null ")
+    class UnknownToDoubleCharacterization {
+
+        private Calc<Object> childCalc;
+        private UnknownToDoubleCalc calc;
+
+        @BeforeEach
+        @SuppressWarnings("unchecked")
+        void setUpCalc() {
+            childCalc = mock(Calc.class);
+            calc = new UnknownToDoubleCalc(NumericType.INSTANCE, childCalc);
+        }
+
+        @Test
+        @DisplayName("Java null input produces Java null")
+        void javaNullProducesJavaNull() {
+            when(childCalc.evaluate(evaluator)).thenReturn(null);
+            assertThat(calc.evaluate(evaluator)).isNull();
+        }
+
+        @Test
+        @DisplayName("Double and other Number inputs are converted to Double")
+        void numberInputsAreConverted() {
+            when(childCalc.evaluate(evaluator)).thenReturn(2.5);
+            assertThat(calc.evaluate(evaluator)).isEqualTo(2.5);
+
+            when(childCalc.evaluate(evaluator)).thenReturn(Integer.valueOf(3));
+            assertThat(calc.evaluate(evaluator)).isEqualTo(3.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("IntegerToDoubleCalc: Java null produces Java null ")
+    class IntegerToDoubleCharacterization {
+
+        private IntegerCalc integerCalc;
+        private IntegerToDoubleCalc calc;
+
+        @BeforeEach
+        void setUpCalc() {
+            integerCalc = mock(IntegerCalc.class);
+            calc = new IntegerToDoubleCalc(NumericType.INSTANCE, integerCalc);
+        }
+
+        @Test
+        @DisplayName("Java null input produces Java null")
+        void javaNullProducesJavaNull() {
+            when(integerCalc.evaluate(evaluator)).thenReturn(null);
+            assertThat(calc.evaluate(evaluator)).isNull();
+        }
+
+        @Test
+        @DisplayName("integer input is widened to Double")
+        void integerIsWidened() {
+            when(integerCalc.evaluate(evaluator)).thenReturn(3);
+            assertThat(calc.evaluate(evaluator)).isEqualTo(3.0);
+
+            when(integerCalc.evaluate(evaluator)).thenReturn(0);
+            assertThat(calc.evaluate(evaluator)).isEqualTo(0.0);
+        }
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/ComparisonNullSemanticsTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/ComparisonNullSemanticsTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.olap.api.calc.DoubleCalc;
+import org.eclipse.daanse.olap.api.evaluator.Evaluator;
+import org.eclipse.daanse.olap.api.type.BooleanType;
+import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.fun.FunUtil;
+import org.eclipse.daanse.olap.function.def.operators.equal.EqualCalc;
+import org.eclipse.daanse.olap.function.def.operators.greater.GreaterCalc;
+import org.eclipse.daanse.olap.function.def.operators.greater.GreaterOrEqualCalc;
+import org.eclipse.daanse.olap.function.def.operators.less.LessCalc;
+import org.eclipse.daanse.olap.function.def.operators.less.LessOrEqualCalc;
+import org.eclipse.daanse.olap.function.def.operators.notequal.NotEqualCalc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * MDX NULL semantics of the numeric comparison operator calcs (MDX NULL is
+ * Java {@code null} in the calc layer): a Java-null (or NaN) operand makes
+ * every comparison return {@code FunUtil.BOOLEAN_NULL}, which is the
+ * primitive {@code false} — no three-valued logic, so a NULL comparison is
+ * indistinguishable from a genuine FALSE; notably even {@code NULL <> x}
+ * yields false.
+ */
+class ComparisonNullSemanticsTest {
+
+    private static final String[] ALL_OPERATORS = { "=", "<>", ">", ">=", "<", "<=" };
+
+    private Evaluator evaluator;
+    private DoubleCalc calc0;
+    private DoubleCalc calc1;
+
+    // The comparison calcs have protected constructors; minimal subclasses make
+    // them instantiable from this dedicated test package.
+    private static final class TestableEqualCalc extends EqualCalc {
+        TestableEqualCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    private static final class TestableNotEqualCalc extends NotEqualCalc {
+        TestableNotEqualCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    private static final class TestableGreaterCalc extends GreaterCalc {
+        TestableGreaterCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    private static final class TestableGreaterOrEqualCalc extends GreaterOrEqualCalc {
+        TestableGreaterOrEqualCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    private static final class TestableLessCalc extends LessCalc {
+        TestableLessCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    private static final class TestableLessOrEqualCalc extends LessOrEqualCalc {
+        TestableLessOrEqualCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        evaluator = mock(Evaluator.class);
+        calc0 = mock(DoubleCalc.class);
+        calc1 = mock(DoubleCalc.class);
+    }
+
+    private Boolean compare(String operator, Double v0, Double v1) {
+        when(calc0.evaluate(evaluator)).thenReturn(v0);
+        when(calc1.evaluate(evaluator)).thenReturn(v1);
+        BooleanType type = BooleanType.INSTANCE;
+        return switch (operator) {
+        case "=" -> new TestableEqualCalc(type, calc0, calc1).evaluate(evaluator);
+        case "<>" -> new TestableNotEqualCalc(type, calc0, calc1).evaluate(evaluator);
+        case ">" -> new TestableGreaterCalc(type, calc0, calc1).evaluate(evaluator);
+        case ">=" -> new TestableGreaterOrEqualCalc(type, calc0, calc1).evaluate(evaluator);
+        case "<" -> new TestableLessCalc(type, calc0, calc1).evaluate(evaluator);
+        case "<=" -> new TestableLessOrEqualCalc(type, calc0, calc1).evaluate(evaluator);
+        default -> throw new IllegalArgumentException(operator);
+        };
+    }
+
+    @ParameterizedTest(name = "{0}: {1} {0} {2} = {3}")
+    @MethodSource("realValueArguments")
+    @DisplayName("Comparisons of two real values follow ordinary Java semantics")
+    void realValueCharacterization(String operator, Double v0, Double v1, Boolean expected) {
+        assertThat(compare(operator, v0, v1)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> realValueArguments() {
+        return Stream.of(
+                Arguments.of("=", 2.0, 2.0, true),
+                Arguments.of("=", 2.0, 3.0, false),
+                Arguments.of("<>", 2.0, 3.0, true),
+                Arguments.of("<>", 2.0, 2.0, false),
+                Arguments.of(">", 3.0, 2.0, true),
+                Arguments.of(">", 2.0, 3.0, false),
+                Arguments.of(">=", 2.0, 2.0, true),
+                Arguments.of(">=", 1.0, 2.0, false),
+                Arguments.of("<", 2.0, 3.0, true),
+                Arguments.of("<", 3.0, 2.0, false),
+                Arguments.of("<=", 2.0, 2.0, true),
+                Arguments.of("<=", 3.0, 2.0, false));
+    }
+
+    @ParameterizedTest(name = "null {0} 2.0 and 2.0 {0} null = false")
+    @ValueSource(strings = { "=", "<>", ">", ">=", "<", "<=" })
+    @DisplayName("A Java-null operand makes every comparison return BOOLEAN_NULL, which is false")
+    void javaNullOperandReturnsBooleanNull(String operator) {
+        // FunUtil.BOOLEAN_NULL is the primitive false — no three-valued logic: NULL comparisons are indistinguishable from FALSE. Even
+        // NULL <> x is false.
+        assertThat(compare(operator, null, 2.0)).isEqualTo(FunUtil.BOOLEAN_NULL).isFalse();
+        assertThat(compare(operator, 2.0, null)).isEqualTo(FunUtil.BOOLEAN_NULL).isFalse();
+    }
+
+    @ParameterizedTest(name = "NaN {0} 2.0 = false")
+    @ValueSource(strings = { "=", "<>", ">", ">=", "<", "<=" })
+    @DisplayName("A NaN operand makes every comparison return BOOLEAN_NULL, which is false")
+    void nanOperandReturnsBooleanNull(String operator) {
+        assertThat(compare(operator, Double.NaN, 2.0)).isFalse();
+        assertThat(compare(operator, 2.0, Double.NaN)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Both operands Java null: every comparison returns false")
+    void bothJavaNullOperandsReturnFalse() {
+        for (String operator : ALL_OPERATORS) {
+            assertThat(compare(operator, null, null))
+                    .as("operator %s with both operands null", operator)
+                    .isFalse();
+        }
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/CompensatedSumTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/CompensatedSumTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.Random;
+
+import org.eclipse.daanse.olap.calc.base.CompensatedSum;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Neumaier summation vs plain double summation
+ * against a BigDecimal reference .
+ */
+class CompensatedSumTest {
+
+    @Test
+    @DisplayName("Classic Kahan failure case: large value entering a small sum is not lost")
+    void largeAddendIsNotLost() {
+        CompensatedSum sum = new CompensatedSum();
+        sum.add(1.0);
+        sum.add(1e100);
+        sum.add(1.0);
+        sum.add(-1e100);
+        assertThat(sum.value()).isEqualTo(2.0);
+
+        // The same sequence with plain doubles collapses to 0.0 — this is the
+        // error class the compensated accumulator removes.
+        double plain = 0.0;
+        plain += 1.0;
+        plain += 1e100;
+        plain += 1.0;
+        plain += -1e100;
+        assertThat(plain).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("10^7 addends of mixed magnitude: compensated result matches BigDecimal reference")
+    void adversarialMixedMagnitudes() {
+        final int n = 10_000_000;
+        // Deterministic pseudo-random values across ~12 orders of magnitude.
+        Random random = new Random(42);
+
+        CompensatedSum compensated = new CompensatedSum();
+        double plain = 0.0;
+        BigDecimal reference = BigDecimal.ZERO;
+        for (int i = 0; i < n; i++) {
+            double v = random.nextDouble() * Math.pow(10, random.nextInt(12) - 4);
+            if ((i & 1) == 0) {
+                v = -v;
+            }
+            compensated.add(v);
+            plain += v;
+            reference = reference.add(new BigDecimal(v, MathContext.DECIMAL128));
+        }
+
+        double referenceValue = reference.doubleValue();
+        double compensatedError = Math.abs(compensated.value() - referenceValue);
+        double plainError = Math.abs(plain - referenceValue);
+
+        // The compensated sum must be within a few ulps of the reference ...
+        assertThat(compensatedError).isLessThanOrEqualTo(4 * Math.ulp(referenceValue));
+        // ... and at least as accurate as the naive loop (usually far better).
+        assertThat(compensatedError).isLessThanOrEqualTo(plainError);
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/ExcelVbaNullSemanticsTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/ExcelVbaNullSemanticsTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.daanse.olap.api.calc.DoubleCalc;
+import org.eclipse.daanse.olap.api.evaluator.Evaluator;
+import org.eclipse.daanse.olap.api.type.NumericType;
+import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.function.def.excel.acos.AcosCalc;
+import org.eclipse.daanse.olap.function.def.excel.asin.AsinhCalc;
+import org.eclipse.daanse.olap.function.def.excel.log10.Log10Calc;
+import org.eclipse.daanse.olap.function.def.excel.sqrtpi.SqrtPiCalc;
+import org.eclipse.daanse.olap.function.def.vba.exp.ExpCalc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MDX NULL semantics of a sample of Excel/VBA function calcs (MDX NULL is
+ * Java {@code null} in the calc layer): every sampled calc maps a Java-null
+ * argument to a Java-null result instead of throwing, and computes real
+ * values normally.
+ */
+class ExcelVbaNullSemanticsTest {
+
+    private Evaluator evaluator;
+    private DoubleCalc argCalc;
+
+    // The calcs have protected constructors; minimal subclasses make them
+    // instantiable from this dedicated test package.
+    private static final class TestableAcosCalc extends AcosCalc {
+        TestableAcosCalc(Type type, DoubleCalc calc) {
+            super(type, calc);
+        }
+    }
+
+    private static final class TestableAsinhCalc extends AsinhCalc {
+        TestableAsinhCalc(Type type, DoubleCalc calc) {
+            super(type, calc);
+        }
+    }
+
+    private static final class TestableLog10Calc extends Log10Calc {
+        TestableLog10Calc(Type type, DoubleCalc calc) {
+            super(type, calc);
+        }
+    }
+
+    private static final class TestableSqrtPiCalc extends SqrtPiCalc {
+        TestableSqrtPiCalc(Type type, DoubleCalc calc) {
+            super(type, calc);
+        }
+    }
+
+    private static final class TestableExpCalc extends ExpCalc {
+        TestableExpCalc(Type type, DoubleCalc calc) {
+            super(type, calc);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        evaluator = mock(Evaluator.class);
+        argCalc = mock(DoubleCalc.class);
+    }
+
+    private void stubArgument(Double value) {
+        when(argCalc.evaluate(evaluator)).thenReturn(value);
+    }
+
+    @Nested
+    @DisplayName("AcosCalc (excel): Java null maps to null")
+    class AcosCalcCharacterization {
+
+        @Test
+        @DisplayName("real value is computed")
+        void realValue() {
+            stubArgument(1.0);
+            assertThat(new TestableAcosCalc(NumericType.INSTANCE, argCalc).evaluate(evaluator))
+                    .isEqualTo(Math.acos(1.0));
+        }
+
+        @Test
+        @DisplayName("Java null input maps to Java null instead of throwing")
+        void javaNullMapsToJavaNull() {
+            stubArgument(null);
+            assertThat(new TestableAcosCalc(NumericType.INSTANCE, argCalc).evaluate(evaluator)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("AsinhCalc (excel): Java null maps to null")
+    class AsinhCalcCharacterization {
+
+        @Test
+        @DisplayName("real value is computed")
+        void realValue() {
+            stubArgument(0.0);
+            assertThat(new TestableAsinhCalc(NumericType.INSTANCE, argCalc).evaluate(evaluator)).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("Java null input maps to Java null")
+        void javaNullMapsToJavaNull() {
+            stubArgument(null);
+            assertThat(new TestableAsinhCalc(NumericType.INSTANCE, argCalc).evaluate(evaluator)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Log10Calc (excel): Java null maps to null")
+    class Log10CalcCharacterization {
+
+        @Test
+        @DisplayName("real value is computed")
+        void realValue() {
+            stubArgument(100.0);
+            assertThat(new TestableLog10Calc(NumericType.INSTANCE, argCalc).evaluate(evaluator)).isEqualTo(2.0);
+        }
+
+        @Test
+        @DisplayName("Java null input maps to Java null instead of throwing")
+        void javaNullMapsToJavaNull() {
+            stubArgument(null);
+            assertThat(new TestableLog10Calc(NumericType.INSTANCE, argCalc).evaluate(evaluator)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("SqrtPiCalc (excel): Java null maps to null")
+    class SqrtPiCalcCharacterization {
+
+        @Test
+        @DisplayName("real value is computed")
+        void realValue() {
+            stubArgument(4.0);
+            assertThat(new TestableSqrtPiCalc(NumericType.INSTANCE, argCalc).evaluate(evaluator))
+                    .isEqualTo(Math.sqrt(4.0 * Math.PI));
+        }
+
+        @Test
+        @DisplayName("Java null input maps to Java null instead of throwing")
+        void javaNullMapsToJavaNull() {
+            stubArgument(null);
+            assertThat(new TestableSqrtPiCalc(NumericType.INSTANCE, argCalc).evaluate(evaluator)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("ExpCalc (vba): Java null maps to null")
+    class ExpCalcCharacterization {
+
+        @Test
+        @DisplayName("real value is computed")
+        void realValue() {
+            stubArgument(1.0);
+            assertThat(new TestableExpCalc(NumericType.INSTANCE, argCalc).evaluate(evaluator)).isEqualTo(Math.E);
+        }
+
+        @Test
+        @DisplayName("Java null input maps to Java null instead of throwing")
+        void javaNullMapsToJavaNull() {
+            stubArgument(null);
+            assertThat(new TestableExpCalc(NumericType.INSTANCE, argCalc).evaluate(evaluator)).isNull();
+        }
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/IsEmptyNullSemanticsTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/IsEmptyNullSemanticsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.daanse.olap.api.calc.Calc;
+import org.eclipse.daanse.olap.api.calc.DoubleCalc;
+import org.eclipse.daanse.olap.api.evaluator.Evaluator;
+import org.eclipse.daanse.olap.api.type.BooleanType;
+import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.function.def.logical.IsEmptyCalc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the uniform {@code IsEmpty} semantics: MDX NULL is Java null
+ * everywhere, so {@code IsEmpty} of any NULL-valued expression is
+ * {@code true} — including computed numeric NULLs such as
+ * {@code NullValue()}. This matches MSAS.
+ */
+class IsEmptyNullSemanticsTest {
+
+    // IsEmptyCalc has a protected constructor; a minimal subclass makes it
+    // instantiable from this dedicated test package.
+    private static final class TestableIsEmptyCalc extends IsEmptyCalc {
+        TestableIsEmptyCalc(Type type, Calc<?> calc) {
+            super(type, calc);
+        }
+    }
+
+    private Evaluator evaluator;
+
+    @BeforeEach
+    void setUp() {
+        evaluator = mock(Evaluator.class);
+    }
+
+    @Test
+    @DisplayName("IsEmpty over a numeric (DoubleCalc) NULL is true - e.g. IsEmpty(NullValue())")
+    void numericNullIsEmpty() {
+        DoubleCalc doubleCalc = mock(DoubleCalc.class);
+        when(doubleCalc.evaluate(evaluator)).thenReturn(null);
+        assertThat(new TestableIsEmptyCalc(BooleanType.INSTANCE, doubleCalc).evaluate(evaluator)).isTrue();
+    }
+
+    @Test
+    @DisplayName("IsEmpty over a numeric (DoubleCalc) value is false")
+    void numericValueIsNotEmpty() {
+        DoubleCalc doubleCalc = mock(DoubleCalc.class);
+        when(doubleCalc.evaluate(evaluator)).thenReturn(42.5);
+        assertThat(new TestableIsEmptyCalc(BooleanType.INSTANCE, doubleCalc).evaluate(evaluator)).isFalse();
+    }
+
+    @Test
+    @DisplayName("IsEmpty over an object-lane null (NULL cell read) is true")
+    @SuppressWarnings("unchecked")
+    void objectNullIsEmpty() {
+        Calc<Object> objectCalc = mock(Calc.class);
+        when(objectCalc.evaluate(evaluator)).thenReturn(null);
+        assertThat(new TestableIsEmptyCalc(BooleanType.INSTANCE, objectCalc).evaluate(evaluator)).isTrue();
+    }
+
+    @Test
+    @DisplayName("IsEmpty over an object-lane value is false")
+    @SuppressWarnings("unchecked")
+    void objectValueIsNotEmpty() {
+        Calc<Object> objectCalc = mock(Calc.class);
+        when(objectCalc.evaluate(evaluator)).thenReturn("value");
+        assertThat(new TestableIsEmptyCalc(BooleanType.INSTANCE, objectCalc).evaluate(evaluator)).isFalse();
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/NullOrderingTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/NullOrderingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.olap.fun.FunUtil;
+import org.eclipse.daanse.olap.fun.sort.Sorter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Ordering semantics of the value comparators:
+ *
+ * <ul>
+ * <li>the double overloads implement the MSAS-compatible total order
+ * {@code -Inf < values < NaN < +Inf}; a primitive {@code double} cannot carry
+ * MDX NULL, so this order has no NULL slot.</li>
+ * <li>NULL ordering exists only at the boxed/object level: the Object
+ * overloads sort Java {@code null} (MDX NULL) below EVERYTHING, including
+ * -Infinity.</li>
+ * </ul>
+ */
+class NullOrderingTest {
+
+    /**
+     * The total order of the double overloads: no NULL slot.
+ */
+    private static final double[] DOUBLE_ORDER = {
+            Double.NEGATIVE_INFINITY,
+            -1.0,
+            0.0,
+            1.0,
+            Double.NaN,
+            Double.POSITIVE_INFINITY };
+
+    private static final String[] DOUBLE_ORDER_NAMES = {
+            "-Inf", "-1", "0", "1", "NaN", "+Inf" };
+
+    /**
+     * The total order of the Object overloads: Java {@code null} sorts below
+     * everything, EVEN below -Infinity.
+ */
+    private static final Object[] OBJECT_ORDER = {
+            null,
+            Double.NEGATIVE_INFINITY,
+            -1.0,
+            0.0,
+            1.0,
+            Double.NaN,
+            Double.POSITIVE_INFINITY };
+
+    private static final String[] OBJECT_ORDER_NAMES = {
+            "null", "-Inf", "-1", "0", "1", "NaN", "+Inf" };
+
+    @Test
+    @DisplayName("FunUtil.compareValues(double,double): full pairwise order -Inf < -1 < 0 < 1 < NaN < +Inf")
+    void funUtilDoubleOverloadPairwiseOrder() {
+        for (int i = 0; i < DOUBLE_ORDER.length; i++) {
+            for (int j = 0; j < DOUBLE_ORDER.length; j++) {
+                assertThat(FunUtil.compareValues(DOUBLE_ORDER[i], DOUBLE_ORDER[j]))
+                        .as("FunUtil.compareValues(%s, %s)", DOUBLE_ORDER_NAMES[i], DOUBLE_ORDER_NAMES[j])
+                        .isEqualTo(Integer.compare(i, j));
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Sorter.compareValues(double,double): full pairwise order -Inf < -1 < 0 < 1 < NaN < +Inf")
+    void sorterDoubleOverloadPairwiseOrder() {
+        for (int i = 0; i < DOUBLE_ORDER.length; i++) {
+            for (int j = 0; j < DOUBLE_ORDER.length; j++) {
+                assertThat(Sorter.compareValues(DOUBLE_ORDER[i], DOUBLE_ORDER[j]))
+                        .as("Sorter.compareValues(%s, %s)", DOUBLE_ORDER_NAMES[i], DOUBLE_ORDER_NAMES[j])
+                        .isEqualTo(Integer.compare(i, j));
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("FunUtil.compareValues(Object,Object): full pairwise order null < -Inf < -1 < 0 < 1 < NaN < +Inf")
+    void funUtilObjectOverloadPairwiseOrder() {
+        // NULL ordering exists ONLY at this object level: Java null (MDX
+        // NULL) sorts below everything, including -Infinity.
+        for (int i = 0; i < OBJECT_ORDER.length; i++) {
+            for (int j = 0; j < OBJECT_ORDER.length; j++) {
+                assertThat(FunUtil.compareValues(OBJECT_ORDER[i], OBJECT_ORDER[j]))
+                        .as("FunUtil.compareValues(%s, %s)", OBJECT_ORDER_NAMES[i], OBJECT_ORDER_NAMES[j])
+                        .isEqualTo(Integer.compare(i, j));
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Sorter.compareValues(Object,Object): full pairwise order null < -Inf < -1 < 0 < 1 < NaN < +Inf")
+    void sorterObjectOverloadPairwiseOrder() {
+        for (int i = 0; i < OBJECT_ORDER.length; i++) {
+            for (int j = 0; j < OBJECT_ORDER.length; j++) {
+                assertThat(Sorter.compareValues(OBJECT_ORDER[i], OBJECT_ORDER[j]))
+                        .as("Sorter.compareValues(%s, %s)", OBJECT_ORDER_NAMES[i], OBJECT_ORDER_NAMES[j])
+                        .isEqualTo(Integer.compare(i, j));
+            }
+        }
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/OperatorNullSemanticsTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/OperatorNullSemanticsTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.olap.api.calc.DoubleCalc;
+import org.eclipse.daanse.olap.api.evaluator.Evaluator;
+import org.eclipse.daanse.olap.api.type.NumericType;
+import org.eclipse.daanse.olap.api.type.Type;
+import org.eclipse.daanse.olap.function.def.operators.divide.DivideCalc;
+import org.eclipse.daanse.olap.function.def.operators.minus.MinusCalc;
+import org.eclipse.daanse.olap.function.def.operators.minus.MinusPrefixCalc;
+import org.eclipse.daanse.olap.function.def.operators.multiply.MultiplyCalc;
+import org.eclipse.daanse.olap.function.def.operators.plus.PlusCalc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * MDX NULL semantics of the arithmetic operator calcs (MDX NULL is Java
+ * {@code null} in the calc layer). Pins the MSAS behavior matrix:
+ * {@code null + x = x}, {@code null - x = -x}, {@code null * x = null},
+ * {@code null / x = null}, {@code x / null = +Infinity} (unless the divide
+ * calc is configured to produce NULL for a NULL denominator).
+ */
+class OperatorNullSemanticsTest {
+
+    private Evaluator evaluator;
+    private DoubleCalc calc0;
+    private DoubleCalc calc1;
+
+    // The operator calcs have protected constructors; minimal subclasses make
+    // them instantiable from this dedicated test package.
+    private static final class TestablePlusCalc extends PlusCalc {
+        TestablePlusCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    private static final class TestableMinusCalc extends MinusCalc {
+        TestableMinusCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    private static final class TestableMinusPrefixCalc extends MinusPrefixCalc {
+        TestableMinusPrefixCalc(Type type, DoubleCalc c0) {
+            super(type, c0);
+        }
+    }
+
+    private static final class TestableMultiplyCalc extends MultiplyCalc {
+        TestableMultiplyCalc(Type type, DoubleCalc c0, DoubleCalc c1) {
+            super(type, c0, c1);
+        }
+    }
+
+    private static final class TestableDivideCalc extends DivideCalc {
+        TestableDivideCalc(Type type, DoubleCalc c0, DoubleCalc c1, boolean nullDenominatorProducesNull) {
+            super(type, c0, c1, nullDenominatorProducesNull);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        evaluator = mock(Evaluator.class);
+        calc0 = mock(DoubleCalc.class);
+        calc1 = mock(DoubleCalc.class);
+    }
+
+    private Double evaluateBinary(Double v0, Double v1,
+            java.util.function.BiFunction<DoubleCalc, DoubleCalc, DoubleCalc> factory) {
+        when(calc0.evaluate(evaluator)).thenReturn(v0);
+        when(calc1.evaluate(evaluator)).thenReturn(v1);
+        return factory.apply(calc0, calc1).evaluate(evaluator);
+    }
+
+    // --- PlusCalc -------------------------------------------------------
+
+    @ParameterizedTest(name = "{0}: {1} + {2} = {3}")
+    @MethodSource("plusArguments")
+    @DisplayName("PlusCalc treats Java-null operands as neutral element")
+    void plusCharacterization(String testName, Double v0, Double v1, Double expected) {
+        Double result = evaluateBinary(v0, v1, (c0, c1) -> new TestablePlusCalc(NumericType.INSTANCE, c0, c1));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> plusArguments() {
+        return Stream.of(
+                Arguments.of("both real values", 2.0, 3.0, 5.0),
+                Arguments.of("Java null left is ignored (null + 3 = 3)", null, 3.0, 3.0),
+                Arguments.of("Java null right is ignored (2 + null = 2)", 2.0, null, 2.0),
+                Arguments.of("both Java null -> null", null, null, null));
+    }
+
+    @Test
+    @DisplayName("PlusCalc returns Java null for null + null")
+    void plusReturnsNullForBothNull() {
+        Double result = evaluateBinary(null, null, (c0, c1) -> new TestablePlusCalc(NumericType.INSTANCE, c0, c1));
+        assertThat(result).isNull();
+    }
+
+    // --- MinusCalc ------------------------------------------------------
+
+    @ParameterizedTest(name = "{0}: {1} - {2} = {3}")
+    @MethodSource("minusArguments")
+    @DisplayName("MinusCalc treats Java-null operands as neutral element")
+    void minusCharacterization(String testName, Double v0, Double v1, Double expected) {
+        Double result = evaluateBinary(v0, v1, (c0, c1) -> new TestableMinusCalc(NumericType.INSTANCE, c0, c1));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> minusArguments() {
+        return Stream.of(
+                Arguments.of("both real values", 5.0, 3.0, 2.0),
+                Arguments.of("Java null left negates the right operand (null - 3 = -3)", null, 3.0, -3.0),
+                Arguments.of("Java null right is ignored (5 - null = 5)", 5.0, null, 5.0),
+                Arguments.of("both Java null -> null", null, null, null));
+    }
+
+    // --- MinusPrefixCalc --------------------------------------------------
+
+    @ParameterizedTest(name = "{0}: -({1}) = {2}")
+    @MethodSource("minusPrefixArguments")
+    @DisplayName("MinusPrefixCalc maps Java null to Java null")
+    void minusPrefixCharacterization(String testName, Double v, Double expected) {
+        when(calc0.evaluate(evaluator)).thenReturn(v);
+        Double result = new TestableMinusPrefixCalc(NumericType.INSTANCE, calc0).evaluate(evaluator);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> minusPrefixArguments() {
+        return Stream.of(
+                Arguments.of("real value", 3.0, -3.0),
+                Arguments.of("Java null -> null", null, null));
+    }
+
+    // --- MultiplyCalc -----------------------------------------------------
+
+    @ParameterizedTest(name = "{0}: {1} * {2} = {3}")
+    @MethodSource("multiplyArguments")
+    @DisplayName("MultiplyCalc returns Java null if either operand is null")
+    void multiplyCharacterization(String testName, Double v0, Double v1, Double expected) {
+        Double result = evaluateBinary(v0, v1, (c0, c1) -> new TestableMultiplyCalc(NumericType.INSTANCE, c0, c1));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> multiplyArguments() {
+        return Stream.of(
+                Arguments.of("both real values", 2.0, 3.0, 6.0),
+                Arguments.of("Java null left -> null (null * x = null)", null, 3.0, null),
+                Arguments.of("Java null right -> null (x * null = null)", 3.0, null, null));
+    }
+
+    // --- DivideCalc, default flag (nullDenominatorProducesNull = false) ----
+
+    @ParameterizedTest(name = "{0}: {1} / {2} = {3}")
+    @MethodSource("divideDefaultArguments")
+    @DisplayName("DivideCalc (default flag): Java-null denominator produces +Infinity")
+    void divideDefaultCharacterization(String testName, Double v0, Double v1, Double expected) {
+        Double result = evaluateBinary(v0, v1,
+                (c0, c1) -> new TestableDivideCalc(NumericType.INSTANCE, c0, c1, false));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> divideDefaultArguments() {
+        return Stream.of(
+                Arguments.of("both real values", 6.0, 3.0, 2.0),
+                Arguments.of("Java null numerator -> null (null / x = null)", null, 3.0, null),
+                Arguments.of("Java null denominator -> +Infinity (x / null = +Inf)",
+                        6.0, null, Double.POSITIVE_INFINITY),
+                Arguments.of("Java null over Java null -> null (numerator wins)", null, null, null));
+    }
+
+    // --- DivideCalc, nullDenominatorProducesNull = true ---------------------
+
+    @ParameterizedTest(name = "{0}: {1} / {2} = {3}")
+    @MethodSource("divideNullFlagArguments")
+    @DisplayName("DivideCalc (nullDenominatorProducesNull=true): Java null anywhere produces null")
+    void divideNullFlagCharacterization(String testName, Double v0, Double v1, Double expected) {
+        Double result = evaluateBinary(v0, v1,
+                (c0, c1) -> new TestableDivideCalc(NumericType.INSTANCE, c0, c1, true));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> divideNullFlagArguments() {
+        return Stream.of(
+                Arguments.of("both real values", 6.0, 3.0, 2.0),
+                Arguments.of("Java null numerator -> null", null, 3.0, null),
+                Arguments.of("Java null denominator -> null", 6.0, null, null));
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/PairedStatisticsAlignmentTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/nullsemantics/PairedStatisticsAlignmentTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.nullsemantics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.daanse.olap.api.calc.Calc;
+import org.eclipse.daanse.olap.api.calc.tuple.TupleList;
+import org.eclipse.daanse.olap.api.element.Member;
+import org.eclipse.daanse.olap.api.evaluator.Evaluator;
+import org.eclipse.daanse.olap.api.execution.Execution;
+import org.eclipse.daanse.olap.api.execution.Statement;
+import org.eclipse.daanse.olap.api.query.component.Query;
+import org.eclipse.daanse.olap.api.type.NumericType;
+import org.eclipse.daanse.olap.calc.base.type.tuplebase.UnaryTupleList;
+import org.eclipse.daanse.olap.fun.FunUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pair alignment of the paired statistics: Covariance and Correlation
+ * evaluate both expressions per tuple and drop a tuple ONLY when one of the
+ * two values is NULL (pairwise deletion) — dropping NULLs per set
+ * independently would silently pair x and y values of different tuples
+ * whenever the NULL patterns differed.
+ */
+class PairedStatisticsAlignmentTest {
+
+    private Evaluator evaluator;
+    private Calc<Object> exp1;
+    private Calc<Object> exp2;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        evaluator = mock(Evaluator.class);
+        Query query = mock(Query.class);
+        Statement statement = mock(Statement.class);
+        Execution execution = mock(Execution.class);
+        when(evaluator.getQuery()).thenReturn(query);
+        when(query.getStatement()).thenReturn(statement);
+        when(statement.getCurrentExecution()).thenReturn(execution);
+
+        exp1 = mock(Calc.class);
+        exp2 = mock(Calc.class);
+        when(exp1.getType()).thenReturn(NumericType.INSTANCE);
+        when(exp2.getType()).thenReturn(NumericType.INSTANCE);
+    }
+
+    private static TupleList tuples(int memberCount) {
+        List<Member> members = new ArrayList<>();
+        for (int i = 0; i < memberCount; i++) {
+            members.add(mock(Member.class));
+        }
+        return new UnaryTupleList(members);
+    }
+
+    @Test
+    @DisplayName("Tuples with a NULL on either side are dropped pairwise, keeping x/y aligned")
+    void covariancePairwiseDeletionKeepsAlignment() {
+        // tuples:      t1      t2      t3      t4
+        // exp1:        1.0     null    3.0     5.0
+        // exp2:        2.0     4.0     null    10.0
+        // aligned pairs: (1,2) and (5,10) -> unbiased covariance:
+        // means (3, 6); ((1-3)(2-6) + (5-3)(10-6)) / (2-1) = (8 + 8) / 1 = 16
+        when(exp1.evaluate(evaluator)).thenReturn(1.0, null, 3.0, 5.0);
+        when(exp2.evaluate(evaluator)).thenReturn(2.0, 4.0, null, 10.0);
+
+        Object covar = FunUtil.covariance(evaluator, tuples(4), exp1, exp2, false);
+
+        assertThat(covar).isInstanceOf(Double.class);
+        assertThat((Double) covar).isEqualTo(16.0);
+        // Dropping NULLs per set instead would pair (1,2),(3,4),(5,10) and
+        // produce a different (wrong) value.
+    }
+
+    @Test
+    @DisplayName("Correlation uses the same aligned pairs for covariance and both variances")
+    void correlationUsesAlignedPairs() {
+        // aligned pairs (1,2) and (5,10) lie exactly on y = 2x -> r == 1
+        when(exp1.evaluate(evaluator)).thenReturn(1.0, null, 5.0);
+        when(exp2.evaluate(evaluator)).thenReturn(2.0, 7.0, 10.0);
+
+        double r = FunUtil.correlation(evaluator, tuples(3), exp1, exp2);
+
+        assertThat(r).isCloseTo(1.0, within(1e-12));
+    }
+
+    @Test
+    @DisplayName("No aligned pairs at all: Covariance is NULL, Correlation NaN")
+    void allPairsIncomplete() {
+        when(exp1.evaluate(evaluator)).thenReturn(1.0, null);
+        when(exp2.evaluate(evaluator)).thenReturn(null, 4.0);
+
+        Object covar = FunUtil.covariance(evaluator, tuples(2), exp1, exp2, false);
+        assertThat(covar).isNull();
+
+        when(exp1.evaluate(evaluator)).thenReturn(1.0, null);
+        when(exp2.evaluate(evaluator)).thenReturn(null, 4.0);
+        assertThat(FunUtil.correlation(evaluator, tuples(2), exp1, exp2)).isNaN();
+    }
+
+    @Test
+    @DisplayName("Biased covariance divides by n")
+    void biasedCovariance() {
+        when(exp1.evaluate(evaluator)).thenReturn(1.0, 5.0);
+        when(exp2.evaluate(evaluator)).thenReturn(2.0, 10.0);
+
+        Object covar = FunUtil.covariance(evaluator, tuples(2), exp1, exp2, true);
+
+        assertThat((Double) covar).isEqualTo(8.0);
+    }
+}

--- a/util.format/src/test/java/org/eclipse/daanse/olap/util/format/FormatEdgeCasesTest.java
+++ b/util.format/src/test/java/org/eclipse/daanse/olap/util/format/FormatEdgeCasesTest.java
@@ -37,13 +37,13 @@ class FormatEdgeCasesTest {
     class NullAndEmptyHandling {
 
         @Test
-        void nullValue() {
+        void nullInput() {
             Format f = new Format("#,##0.00", Locale.US);
             assertThat(f.format(null)).isEqualTo("");
         }
 
         @Test
-        void nullValueWithFourSections() {
+        void nullInputWithFourSections() {
             Format f = new Format("#,##0.00;(#,##0.00);Zero;Null", Locale.US);
             assertThat(f.format(null)).isEqualTo("Null");
         }

--- a/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/execute/XmlaNullCellCharacterizationTest.java
+++ b/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/execute/XmlaNullCellCharacterizationTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.xmla.bridge.execute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.daanse.olap.api.execution.Statement;
+import org.eclipse.daanse.olap.api.element.Cube;
+import org.eclipse.daanse.olap.api.element.Hierarchy;
+import org.eclipse.daanse.olap.api.element.Level;
+import org.eclipse.daanse.olap.api.element.Member;
+import org.eclipse.daanse.olap.api.query.component.Query;
+import org.eclipse.daanse.olap.api.query.component.QueryComponent;
+import org.eclipse.daanse.olap.api.result.Cell;
+import org.eclipse.daanse.olap.api.result.CellSet;
+import org.eclipse.daanse.olap.api.result.CellSetAxis;
+import org.eclipse.daanse.olap.api.result.CellSetAxisMetaData;
+import org.eclipse.daanse.olap.api.result.CellSetMetaData;
+import org.eclipse.daanse.olap.api.result.Position;
+import org.eclipse.daanse.xmla.api.execute.statement.StatementResponse;
+import org.eclipse.daanse.xmla.model.record.mddataset.CellTypeR;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * XMLA serialization contract for NULL cells in
+ * {@link XmlaResponseConverter#toStatementResponseMddataset}:
+ * <ul>
+ * <li>a NULL cell whose cell properties are all null is omitted from CellData
+ * entirely — except at ordinal 0,</li>
+ * <li>a NULL cell with a non-null property (e.g. FORMATTED_VALUE) is emitted
+ * WITHOUT a &lt;Value&gt; element,</li>
+ * <li>Double.POSITIVE_INFINITY is serialized as the string "INF",</li>
+ * <li>a regular Double value keeps its numeric string form,</li>
+ * <li>an error cell serializes its Throwable as xsd:string.</li>
+ * </ul>
+ */
+class XmlaNullCellCharacterizationTest {
+
+    private CellSet cellSet;
+    private CellSetAxis columnsAxis;
+    private CellSetAxis filterAxis;
+
+    @BeforeEach
+    void setUp() {
+        cellSet = mock(CellSet.class);
+
+        Statement statement = mock(Statement.class);
+        Query query = mock(Query.class);
+        lenient().when(cellSet.getStatement()).thenReturn(statement);
+        lenient().when(statement.getQuery()).thenReturn(query);
+        // no explicit CELL PROPERTIES in the MDX -> defaults VALUE + FORMATTED_VALUE
+        lenient().when(query.getCellProperties()).thenReturn(new QueryComponent[0]);
+
+        CellSetMetaData metaData = mock(CellSetMetaData.class);
+        Cube cube = mock(Cube.class);
+        lenient().when(cellSet.getMetaData()).thenReturn(metaData);
+        lenient().when(metaData.getCube()).thenReturn(cube);
+        lenient().when(cube.getName()).thenReturn("SalesCube");
+
+        columnsAxis = mock(CellSetAxis.class);
+        filterAxis = mock(CellSetAxis.class);
+        lenient().when(cellSet.getAxes()).thenReturn(List.of(columnsAxis));
+        lenient().when(cellSet.getFilterAxis()).thenReturn(filterAxis);
+
+        // filter axis: empty WHERE clause -> no positions, no hierarchies
+        CellSetAxisMetaData filterAxisMetaData = mock(CellSetAxisMetaData.class);
+        lenient().when(filterAxis.getPositions()).thenReturn(List.of());
+        lenient().when(filterAxis.getAxisMetaData()).thenReturn(filterAxisMetaData);
+        lenient().when(filterAxisMetaData.getHierarchies()).thenReturn(List.of());
+        lenient().when(filterAxisMetaData.getProperties()).thenReturn(List.of());
+    }
+
+    /** One measure member per column position, all on the Measures hierarchy. */
+    private void mockAxisPositions(int count) {
+        Hierarchy hierarchy = mock(Hierarchy.class);
+        lenient().when(hierarchy.getName()).thenReturn("Measures");
+        lenient().when(hierarchy.getUniqueName()).thenReturn("[Measures]");
+        Level level = mock(Level.class);
+
+        Position[] positions = new Position[count];
+        for (int i = 0; i < count; i++) {
+            Member member = mock(Member.class);
+            lenient().when(member.getLevel()).thenReturn(level);
+            lenient().when(member.getHierarchy()).thenReturn(hierarchy);
+            lenient().when(member.getPropertyValue("MEMBER_UNIQUE_NAME")).thenReturn("[Measures].[M" + i + "]");
+            lenient().when(member.getPropertyValue("MEMBER_CAPTION")).thenReturn("M" + i);
+            lenient().when(member.getPropertyValue("LEVEL_UNIQUE_NAME")).thenReturn("[Measures].[MeasuresLevel]");
+            lenient().when(member.getPropertyValue("LEVEL_NUMBER")).thenReturn(0);
+            // primitive int in calculateDisplayInfo -> must not be null
+            lenient().when(member.getPropertyValue("CHILDREN_CARDINALITY")).thenReturn(0);
+
+            Position position = mock(Position.class);
+            List<Member> members = List.of(member);
+            lenient().when(position.getMembers()).thenReturn(members);
+            lenient().when(position.iterator()).thenAnswer(inv -> members.iterator());
+            positions[i] = position;
+        }
+        lenient().when(columnsAxis.getPositions()).thenReturn(List.of(positions));
+        // null axis metadata -> converter falls back to its default properties
+        lenient().when(columnsAxis.getAxisMetaData()).thenReturn(null);
+    }
+
+    private void mockCells(Cell... cells) {
+        when(cellSet.getCell(anyList())).thenAnswer(inv -> {
+            List<Integer> pos = inv.getArgument(0);
+            return cells[pos.get(0)];
+        });
+    }
+
+    private static Cell valueCell(Object value, String formatted) {
+        Cell cell = mock(Cell.class);
+        lenient().when(cell.isNull()).thenReturn(false);
+        lenient().when(cell.getValue()).thenReturn(value);
+        lenient().when(cell.getPropertyValue("VALUE")).thenReturn(value);
+        lenient().when(cell.getPropertyValue("FORMATTED_VALUE")).thenReturn(formatted);
+        return cell;
+    }
+
+    /**
+     * A NULL cell that still carries a non-null (empty) FORMATTED_VALUE, the
+     * way a formatted NULL measure is reported.
+ */
+    private static Cell formattedNullCell() {
+        Cell cell = mock(Cell.class);
+        lenient().when(cell.isNull()).thenReturn(true);
+        lenient().when(cell.getValue()).thenReturn(null);
+        lenient().when(cell.getPropertyValue("VALUE")).thenReturn(null);
+        lenient().when(cell.getPropertyValue("FORMATTED_VALUE")).thenReturn("");
+        return cell;
+    }
+
+    /** A NULL cell whose cell properties are all null. */
+    private static Cell bareNullCell() {
+        Cell cell = mock(Cell.class);
+        lenient().when(cell.isNull()).thenReturn(true);
+        lenient().when(cell.getValue()).thenReturn(null);
+        lenient().when(cell.getPropertyValue("VALUE")).thenReturn(null);
+        lenient().when(cell.getPropertyValue("FORMATTED_VALUE")).thenReturn(null);
+        return cell;
+    }
+
+    private List<org.eclipse.daanse.xmla.api.mddataset.CellType> convert() {
+        StatementResponse response = XmlaResponseConverter.toStatementResponseMddataset(cellSet, true, false);
+        return response.mdDataSet().cellData().cell();
+    }
+
+    @Test
+    @DisplayName("Regular double cell keeps value; NULL cell with formatted value is emitted without <Value>")
+    void nullCellWithFormattedValueIsEmittedWithoutValue() {
+        mockAxisPositions(2);
+        mockCells(valueCell(42.5d, "42.5"), formattedNullCell());
+
+        List<org.eclipse.daanse.xmla.api.mddataset.CellType> cells = convert();
+
+        assertThat(cells).hasSize(2);
+
+        CellTypeR value = (CellTypeR) cells.get(0);
+        assertThat(value.cellOrdinal()).isZero();
+        assertThat(value.value()).isNotNull();
+        assertThat(value.value().value()).isEqualTo("42.5");
+
+        // The NULL cell is NOT omitted (FORMATTED_VALUE is non-null), but the
+        // VALUE property is skipped because cell.isNull() -> no <Value> element.
+        CellTypeR nullCell = (CellTypeR) cells.get(1);
+        assertThat(nullCell.cellOrdinal()).isEqualTo(1);
+        assertThat(nullCell.value()).isNull();
+        assertThat(nullCell.any()).anySatisfy(item -> {
+            assertThat(item.tagName()).isEqualTo("FmtValue");
+            assertThat(item.name()).isEmpty();
+        });
+    }
+
+    @Test
+    @DisplayName("NULL cell with all-null properties is omitted from CellData (MSAS style), except at ordinal 0")
+    void bareNullCellIsOmittedExceptAtOrdinalZero() {
+        mockAxisPositions(3);
+        mockCells(valueCell(1.0d, "1"), bareNullCell(), valueCell(2.0d, "2"));
+
+        List<org.eclipse.daanse.xmla.api.mddataset.CellType> cells = convert();
+
+        // ordinal 1 is dropped entirely; remaining cells keep their ordinals
+        assertThat(cells).hasSize(2);
+        assertThat(cells).extracting(org.eclipse.daanse.xmla.api.mddataset.CellType::cellOrdinal)
+                .containsExactly(0L, 2L);
+    }
+
+    @Test
+    @DisplayName("NULL cell at ordinal 0 is always emitted, even with all-null properties")
+    void bareNullCellAtOrdinalZeroIsEmitted() {
+        mockAxisPositions(1);
+        mockCells(bareNullCell());
+
+        List<org.eclipse.daanse.xmla.api.mddataset.CellType> cells = convert();
+
+        assertThat(cells).hasSize(1);
+        CellTypeR nullCell = (CellTypeR) cells.get(0);
+        assertThat(nullCell.cellOrdinal()).isZero();
+        assertThat(nullCell.value()).isNull();
+        assertThat(nullCell.any()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Double.POSITIVE_INFINITY (the x/NULL result) is serialized as INF")
+    void positiveInfinityIsSerializedAsInf() {
+        mockAxisPositions(1);
+        mockCells(valueCell(Double.POSITIVE_INFINITY, "Infinity"));
+
+        List<org.eclipse.daanse.xmla.api.mddataset.CellType> cells = convert();
+
+        assertThat(cells).hasSize(1);
+        CellTypeR infCell = (CellTypeR) cells.get(0);
+        assertThat(infCell.value()).isNotNull();
+        assertThat(infCell.value().value()).isEqualTo("INF");
+    }
+
+    /**
+     * Error cells: the evaluation error is stored as the cell VALUE (a
+     * Throwable) and the formatted value carries the "#ERR:" text. The
+     * converter has no error-specific branch: the Throwable falls through
+     * ValueInfo's default case and is serialized as its toString() with type
+     * xsd:string. Cell.getValue()/getPropertyValue must keep returning the
+     * Throwable so this serialization stays stable.
+ */
+    @Test
+    @DisplayName("Error cell serializes the Throwable's toString as xsd:string, FmtValue carries #ERR:")
+    void errorCellSerializesThrowableAsString() {
+        mockAxisPositions(1);
+        RuntimeException failure = new RuntimeException("boom");
+        Cell errorCell = mock(Cell.class);
+        lenient().when(errorCell.isNull()).thenReturn(false);
+        lenient().when(errorCell.getValue()).thenReturn(failure);
+        lenient().when(errorCell.getPropertyValue("VALUE")).thenReturn(failure);
+        lenient().when(errorCell.getPropertyValue("FORMATTED_VALUE")).thenReturn("#ERR: " + failure);
+        mockCells(errorCell);
+
+        List<org.eclipse.daanse.xmla.api.mddataset.CellType> cells = convert();
+
+        assertThat(cells).hasSize(1);
+        CellTypeR cell = (CellTypeR) cells.get(0);
+        assertThat(cell.value()).isNotNull();
+        assertThat(cell.value().value()).contains("boom");
+        assertThat(cell.any()).anySatisfy(item -> {
+            assertThat(item.tagName()).isEqualTo("FmtValue");
+            assertThat(item.name()).startsWith("#ERR:");
+        });
+    }
+
+}


### PR DESCRIPTION
MDX NULL used to be the magic double 0.000000012345 and a not-yet-loaded
cell a literal Double(0) - both real numbers that flowed through
arithmetic, collided with legitimate values and were filtered back out
by identity comparisons. This replaces the in-band encodings with
explicit representations at each layer:

- The calc layer represents MDX NULL as Java null; the central
  NullSemantics class is the single home of the NULL rules (checks,
  MSAS-compatible ordering, comparator implementations). A genuine
  computation result of 0.000000012345 is a real value everywhere.
- A not-yet-loaded cell is the non-numeric NotLoaded marker: accidental
  arithmetic with it fails fast instead of silently producing values;
  the discarded batching pass tolerates it explicitly.
- The cell/cache boundary uses the sealed CellValue state type
  (NullValue | NotLoaded | ErrorValue | ObjectValue) with exhaustive,
  compiler-checked switches; the cache probe API keeps the legacy
  object convention for external consumers. Cell.getValue() contract
  corrected: Java null for NULL cells, Throwable for error cells.
- Double aggregates sum through a compensated (Neumaier) accumulator,
  bounding rounding error at ~1 ulp independent of set size.
- Covariance/Correlation evaluate pairwise and drop tuples with a NULL
  on either side, instead of silently pairing values of different
  tuples. Empty Sum returns null; VBA coercions handle NULL like the
  old encoding did observably (CInt/Int -> 0, CDbl passes through).
- IsEmpty of any NULL-valued expression is true (MSAS-conform); the
  historical false for computed numeric NULLs was a sentinel artifact.