### PR TITLE
refactor!: adopt the sql.dialect/sql.model coordinates from the jdbc.…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -36,7 +36,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.daanse</groupId>
-			<artifactId>org.eclipse.daanse.jdbc.db.dialect.api</artifactId>
+			<artifactId>org.eclipse.daanse.sql.dialect.api</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>

--- a/api/src/main/java/org/eclipse/daanse/olap/api/Context.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/Context.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Semaphore;
 
 import javax.sql.DataSource;
 
-import org.eclipse.daanse.jdbc.db.dialect.api.Dialect;
+import org.eclipse.daanse.sql.dialect.api.Dialect;
 import org.eclipse.daanse.mdx.parser.api.MdxParserProvider;
 import org.eclipse.daanse.olap.api.agg.AggregationFactory;
 import org.eclipse.daanse.olap.api.aggregator.CustomAggregatorFactory;

--- a/api/src/main/java/org/eclipse/daanse/olap/api/element/Level.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/element/Level.java
@@ -30,7 +30,7 @@ package org.eclipse.daanse.olap.api.element;
 
 import java.util.List;
 
-import org.eclipse.daanse.jdbc.db.api.type.Datatype;
+import org.eclipse.daanse.sql.model.type.Datatype;
 import org.eclipse.daanse.olap.api.formatter.MemberFormatter;
 import org.eclipse.daanse.olap.api.sql.SqlExpression;
 

--- a/common/src/main/java/org/eclipse/daanse/olap/util/Bug.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/util/Bug.java
@@ -23,7 +23,7 @@
  */
 package org.eclipse.daanse.olap.util;
 
-import org.eclipse.daanse.jdbc.db.dialect.api.Dialect;
+import org.eclipse.daanse.sql.dialect.api.Dialect;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/isdate/IsDateCalcTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/isdate/IsDateCalcTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Date;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
@@ -32,9 +33,24 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class IsDateCalcTest {
 
+    // The fixture strings ("October 19, 1962", "4:35:47 PM") are US-locale forms and
+    // IsDate parses with the default locale — pin it so the expectations hold everywhere.
+    private static Locale defaultLocale;
+
     private IsDateCalc isDateCalc;
     private Calc<Object> inputCalc;
     private Evaluator evaluator;
+
+    @org.junit.jupiter.api.BeforeAll
+    static void pinLocale() {
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+    }
+
+    @org.junit.jupiter.api.AfterAll
+    static void restoreLocale() {
+        Locale.setDefault(defaultLocale);
+    }
 
     @BeforeEach
     void setUp() {

--- a/common/test.bndrun
+++ b/common/test.bndrun
@@ -62,15 +62,15 @@
 	net.bytebuddy.byte-buddy;version='[1.17.5,1.17.6)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.17.5,1.17.6)',\
 	org.apache.felix.scr;version='[2.2.10,2.2.11)',\
-	org.eclipse.daanse.jdbc.db.api;version='[0.0.1,0.0.2)',\
-	org.eclipse.daanse.jdbc.db.dialect.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.mdx.model.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.mdx.parser.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.common;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.common-tests;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.util.format;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.sql.dialect.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.sql.guard.api;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.sql.model;version='[0.0.1,0.0.2)',\
 	org.mockito.junit-jupiter;version='[4.9.0,4.9.1)',\
 	org.mockito.mockito-core;version='[4.9.0,4.9.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/CSDLUtils.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/CSDLUtils.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.eclipse.daanse.jdbc.db.api.type.Datatype;
+import org.eclipse.daanse.sql.model.type.Datatype;
 import org.eclipse.daanse.olap.api.element.Catalog;
 import org.eclipse.daanse.olap.api.element.Cube;
 import org.eclipse.daanse.olap.api.element.Dimension;

--- a/xmla/bridge/test.bndrun
+++ b/xmla/bridge/test.bndrun
@@ -63,8 +63,6 @@
 	net.bytebuddy.byte-buddy-agent;version='[1.17.5,1.17.6)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.scr;version='[2.2.10,2.2.11)',\
-	org.eclipse.daanse.jdbc.db.api;version='[0.0.1,0.0.2)',\
-	org.eclipse.daanse.jdbc.db.dialect.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.lcid.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.mdx.model.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.mdx.parser.api;version='[0.0.1,0.0.2)',\
@@ -73,7 +71,9 @@
 	org.eclipse.daanse.olap.util.format;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.xmla.bridge;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.xmla.bridge-tests;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.sql.dialect.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.sql.guard.api;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.sql.model;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.xmla.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.xmla.csdl.model.v2.an;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.xmla.csdl.model.v2.bi;version='[0.0.1,0.0.2)',\


### PR DESCRIPTION
…db split

The dialect framework and the SQL vocabulary moved to the org.eclipse.daanse.sql repository (plain file copies; history in jdbc.db). Mechanical rename: imports/deps/bndrun BSNs org.eclipse.daanse.jdbc.db.dialect.* -> org.eclipse.daanse.sql.dialect.*, org.eclipse.daanse.jdbc.db.api.type -> org.eclipse.daanse.sql.model.type; the test bndruns additionally run the sql.model bundle.
