### PR TITLE
migrate csdl util to emitters

### DIFF
--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/OtherDiscoverService.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/OtherDiscoverService.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -353,7 +354,7 @@ public class OtherDiscoverService {
                 if (catalog != null) {
                     //TSchema schema = CSDLUtils.getCSDLModel(catalog, perspectiveName);
                     CatalogReader reader = catalog.getCatalogReaderWithDefaultRole();
-                    LocalePolicy lp = new LocalePolicy.ServerDefault();
+                    LocalePolicy lp = new LocalePolicy.ServerDefault(Locale.getDefault());
                     CsdlRequest req = new CsdlRequest(CsdlVersion.V2_0, perspectiveName, lp);
                     TSchema schema = csdlEmitter.emit(reader, req);
                     //result.add(new DiscoverCsdlMetaDataResponseRowR(CSDLUtils.getCSDL(catalog, perspectiveName)));

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/CsdlEmitterImpl.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/CsdlEmitterImpl.java
@@ -22,11 +22,14 @@ import org.eclipse.daanse.olap.api.element.Dimension;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.xmla.bridge.discover.csdl.dimensional.AssociationEmitter.RelationshipUsage;
 import org.eclipse.daanse.xmla.csdl.model.v2.bi.BiFactory;
+import org.eclipse.daanse.xmla.csdl.model.v2.bi.BiPackage;
 import org.eclipse.daanse.xmla.csdl.model.v2.bi.TEntityContainer;
 import org.eclipse.daanse.xmla.csdl.model.v2.bi.TEntityType;
 import org.eclipse.daanse.xmla.csdl.model.v2.edm.EdmFactory;
 import org.eclipse.daanse.xmla.csdl.model.v2.edm.EntityContainerType;
 import org.eclipse.daanse.xmla.csdl.model.v2.edm.TSchema;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.ExtendedMetaData;
 
 public class CsdlEmitterImpl implements CsdlEmitter{
     private static EdmFactory edmFactory = EdmFactory.eINSTANCE;
@@ -46,12 +49,17 @@ public class CsdlEmitterImpl implements CsdlEmitter{
                 
                 TSchema schema = edmFactory.createTSchema();
                 schema.setNamespace(names.namespaceOf(catalog));
+                
+                EStructuralFeature versionFeature = ExtendedMetaData.INSTANCE
+                        .demandFeature(BiPackage.eNS_URI, "Version", false);
+                schema.getAnyAttribute().add(versionFeature, req.version());
+                
                 EntityContainerType container = edmFactory.createEntityContainerType();
                 container.setName(names.namespaceOf(catalog));
 
                 TEntityContainer biContainer = biFactory.createTEntityContainer();
                 biContainer.setCaption(cube.getName());
-                biContainer.setCulture("en-US");
+                biContainer.setCulture(req.localePolicy().locale().getDisplayName());
                 //biContainer.setCulture("de-DE");
                 container.setBiEntityContainer(biContainer);
                 schema.getEntityContainer().add(container);
@@ -72,8 +80,9 @@ public class CsdlEmitterImpl implements CsdlEmitter{
                                 .createTEntityType();
                         TEntityType biEntityType = biFactory.createTEntityType();
                         edmEntityType.setBiEntityType(biEntityType);
-                        
                         edmEntityType.setName(names.tableNameOf(dimension));
+                        dimensionEntityEmitter.emitDimensionEntity(schema, container, cube, dimension, ctx);
+                        
                         schema.getEntityType().add(edmEntityType);
                         if (dimension.isMeasures()) {
                             List<Member> measures = cube.getMeasures();
@@ -86,9 +95,8 @@ public class CsdlEmitterImpl implements CsdlEmitter{
                                 calculatedMeasureEmitter.emit(reader, cube);
                             }
                         } else {
-                            RelationshipUsage relationshipUsage = new RelationshipUsage(dimension, Optional.empty(), Optional.empty(), true);
+                            RelationshipUsage relationshipUsage = new RelationshipUsage(oMeasureDimension.get(), Optional.empty(), Optional.empty(), true);
                             hierarchyEmitter.emitDimension(dimension, edmEntityType, biEntityType);
-                            dimensionEntityEmitter.emitDimensionEntity(schema, container, cube, dimension, ctx);
                             associationEmitter.emit(cube, dimension, relationshipUsage);
                         }
                     }
@@ -98,7 +106,7 @@ public class CsdlEmitterImpl implements CsdlEmitter{
                 throw new CsdlEmitException("Cube is absent");
             }
         } else {
-            throw new CsdlEmitException("Cube is absent");
+            throw new CsdlEmitException("perspective is absent in requers");
         }
     }
 

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/DefaultTypeMapper.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/DefaultTypeMapper.java
@@ -78,8 +78,9 @@ public final class DefaultTypeMapper implements TypeMapper {
                 new EdmType.Facets(true, null, null, null, Boolean.TRUE, Boolean.FALSE));
     }
     private static EdmType decimal(int p, int s) {
-        return new EdmType(EDMSimpleType.DECIMAL, new EdmType.Facets(false,
-                BigInteger.valueOf(p), BigInteger.valueOf(s), null, false, false));
+        return new EdmType(EDMSimpleType.DECIMAL, EdmType.Facets.NONE);
+        //return new EdmType(EDMSimpleType.DECIMAL, new EdmType.Facets(false,
+        //        BigInteger.valueOf(p), BigInteger.valueOf(s), null, false, false));
     }
     private static EdmType plain(EDMSimpleType t) {
         return new EdmType(t, EdmType.Facets.NONE);
@@ -87,80 +88,62 @@ public final class DefaultTypeMapper implements TypeMapper {
 
     @Override
     public void apply(TEntityProperty p, Datatype datatype) {
-        p.setType(getType(datatype));
+        p.setType(getType(datatype).type());
     }
 
     @Override
     public void apply(TEntityProperty p, org.eclipse.daanse.olap.api.element.Property.Datatype type) {
-        p.setType(getType(type));
+        p.setType(getType(type).type());
     }
 
     private EdmType widenForSum(EdmType t) {
         return decimal(19, 4);
     }
 
-    private String getType(Datatype type) {
+    private EdmType getType(Datatype type) {
         if (type != null) {
             switch (type) {
             case VARCHAR:
-                return "String";
-            case NUMERIC:
-                return "Decimal";
-            case INTEGER:
-                return "Int64";
-            case BIGINT:
-                return "Int64";
-            case SMALLINT:
-                return "Int64";
+                return stringType();
+            case NUMERIC, DECIMAL:
+                return decimal(19, 4);
+            case INTEGER, BIGINT, SMALLINT:
+                return plain(EDMSimpleType.INT64);
             case BOOLEAN:
-                return "Boolean";
-            case DATE:
-                return "DateTime";
+                return plain(EDMSimpleType.BOOLEAN);
+            case DATE, TIMESTAMP:
+                return plain(EDMSimpleType.DATE_TIME);
             case TIME:
-                return "DateTime";
-            case TIMESTAMP:
-                return "Timestamp";
-            case DOUBLE:
-                return "Double";
-            case REAL:
-                return "Double";
-            case FLOAT:
-                return "Double";
-            case DECIMAL:
-                return "Decimal";
+                return plain(EDMSimpleType.TIME);
+            case DOUBLE, REAL, FLOAT:
+                return plain(EDMSimpleType.DOUBLE);
             default:
-                return "String";
+                return stringType();
             }
         }
-        return "String";
+        return stringType();
     }
     
-    private String getType(org.eclipse.daanse.olap.api.element.Property.Datatype type) {
+    private EdmType getType(org.eclipse.daanse.olap.api.element.Property.Datatype type) {
         if (type != null) {
             switch (type) {
             case TYPE_STRING:
-                return "String";
+                return stringType();
             case TYPE_NUMERIC:
-                return "Decimal";
-            case TYPE_INTEGER:
-                return "Int64";
-            case TYPE_LONG:
-                return "Int64";
+                return decimal(19, 4);
+            case TYPE_INTEGER, TYPE_LONG:
+                return plain(EDMSimpleType.INT64);
             case TYPE_BOOLEAN:
-                return "Boolean";
-            case TYPE_DATE:
-                return "DateTime";
-            case TYPE_TIME:
-                return "DateTime";
-            case TYPE_TIMESTAMP:
-                return "Timestamp";
+                return plain(EDMSimpleType.BOOLEAN);
+            case TYPE_DATE, TYPE_TIME, TYPE_TIMESTAMP:
+                return plain(EDMSimpleType.DATE_TIME);
             case TYPE_OTHER:
-                return "String";
+                return stringType();
             default:
-                return "String";
+                return stringType();
             }
         }
-        return "String";
+        return stringType();
     }
 
     @Override

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/DimensionEntityEmitter.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/DimensionEntityEmitter.java
@@ -33,56 +33,23 @@ import org.eclipse.emf.ecore.util.FeatureMapUtil;
 
 public class DimensionEntityEmitter {
 
-    TEntityProperty levelProperty(TEntityType owner, Level level, EmitContext ctx) {
-        TEntityProperty p = ctx.edm().createTEntityProperty();
-        p.setName(ctx.names().columnNameOf(level));
-        EdmType t = ctx.types().levelType(level.getDatatype());
-        p.setType(t.type().getLiteral());
-        applyFacets(p, t.facets());
-        TProperty biProp = ctx.bi().createTProperty();
-        biProp.setCaption(level.getCaption());
-        p.setBiProperty(biProp);
-        owner.getProperty().add(p);
-        ctx.registerProperty(owner.getName(), p.getName());
-        return p;
-    }
-    
- private void applyFacets(TEntityProperty p, Facets f) {
-     if (f != null) {
-         p.setMaxLength(f.maxLength());
-         p.setNullable(f.nullable());
-         p.setPrecision(f.precision());
-         p.setScale(f.scale());
-         p.setUnicode(f.unicode());
-         p.setFixedLength(f.fixedLength());
-     }
-        
-    }
-
     void emitDimensionEntity(TSchema schema, EntityContainerType container,
                              Cube cube, Dimension dim, EmitContext ctx) {
         String table = ctx.names().tableNameOf(dim);
-        String qname = ctx.names().namespaceOf(ctx.catalog()) + "." + table;
-
         EntitySetType entitySet = ctx.edm().createEntitySetType();
         entitySet.setName(table);
-        entitySet.setEntityType(qname);
-        TEntitySet biSet = ctx.bi().createTEntitySet();
-        biSet.setCaption(dim.getCaption());
+        entitySet.setEntityType(ctx.qualified(table));
+        
+        attachDocumentation(entitySet::setDocumentation, dim, ctx);
+        
+        TEntitySet biEntitySet = ctx.bi().createTEntitySet();
         if (!dim.isVisible()) {
-            biSet.setHidden(true);
+            biEntitySet.setHidden(true);
         }
-        if (!table.equals(dim.getName())) {
-            biSet.setReferenceName(dim.getName());
-        }
-        entitySet.setBiEntitySet(biSet);
-        container.getEntitySet().add(entitySet);
+        biEntitySet.setCaption(table);
+        entitySet.setBiEntitySet(biEntitySet);
 
-        TEntityType entityType = ctx.edm().createTEntityType();
-        entityType.setName(table);
-        entityType.setBiEntityType(ctx.bi().createTEntityType());
-        attachDocumentation(entityType::setDocumentation, dim, ctx);
-        schema.getEntityType().add(entityType);
+        container.getEntitySet().add(entitySet);
     }
     
     

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/DisplayFolderBuilder.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/DisplayFolderBuilder.java
@@ -45,10 +45,11 @@ public class DisplayFolderBuilder {
           biEntity.getDisplayFolders().getDisplayFolder().add(dFolder);
         }
     }
+
     private List<String> getFolders(String displayFolder) {
-        if (displayFolder != null) {
-            Arrays.asList(displayFolder.split(Pattern.quote("\\")));
+        if (displayFolder == null || displayFolder.isBlank()) {
+            return List.of();
         }
-        return List.of();
+        return Arrays.asList(displayFolder.split("[\\\\/]"));
     }
 }

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/HierarchyEmitter.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/HierarchyEmitter.java
@@ -23,7 +23,6 @@ import org.eclipse.daanse.olap.api.element.DimensionType;
 import org.eclipse.daanse.olap.api.element.Hierarchy;
 import org.eclipse.daanse.olap.api.element.Level;
 import org.eclipse.daanse.olap.api.element.Property;
-import org.eclipse.daanse.olap.api.type.LevelType;
 import org.eclipse.daanse.xmla.csdl.model.v2.bi.BiFactory;
 import org.eclipse.daanse.xmla.csdl.model.v2.bi.ContainsHiddenMembersType;
 import org.eclipse.daanse.xmla.csdl.model.v2.bi.SourceType;

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/LocalePolicy.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/LocalePolicy.java
@@ -16,6 +16,8 @@ import java.util.Locale;
 
 public sealed interface LocalePolicy {
     record Fixed(Locale locale) implements LocalePolicy {}
-    record FromConnection() implements LocalePolicy {}
-    record ServerDefault() implements LocalePolicy {}
+    record FromConnection(Locale locale) implements LocalePolicy {}
+    record ServerDefault(Locale locale) implements LocalePolicy {}
+    
+    public  Locale locale();
 }

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/MeasuresEntity.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/MeasuresEntity.java
@@ -40,6 +40,7 @@ public class MeasuresEntity {
         TDocumentation documentation = edmFactory.createTDocumentation();
         TText summary = edmFactory.createTText();
         summary.getMixed().add(FeatureMapUtil.createRawTextEntry(description));
+        documentation.setSummary(summary);
         anchor.setDocumentation(documentation);
     }
 

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/MeasuryEmiter.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/csdl/dimensional/MeasuryEmiter.java
@@ -160,8 +160,7 @@ public class MeasuryEmiter {
     }
 
     private boolean isEmittedVisibleMeasure(Member def, EmitContext ctx) {
-        // TODO
-        return false;
+        return !def.isHidden();
     }
 
     private void applyFormatAndVisibility(TMeasure bi, Member member) {


### PR DESCRIPTION
Signed-off-by: dbulahov <bulahovdenis@gmail.com>

### What does this PR do?

This PR fixed bugs with csdl emitters implementation.
"csdl emitters implementation"  this is migration of CSDLUtils to emitters classes. 

1. "Version" was added to DISCOVER_CSDL_METADATA response
2. fixed bugs in TypeMapper
3. TEntityType was add to EntityContainerType in DimensionEntityEmitter
4. fixed bugs in DisplayFolderBuilder
5. locale was added to csdl request

