### PR TITLE
feat(function)!: expressive function metadata and a traceable resolver

### DIFF
--- a/api/src/main/java/org/eclipse/daanse/olap/api/DataType.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/DataType.java
@@ -72,7 +72,7 @@ public enum DataType {
         return name;
     }
 
-    public String getPrittyName() {
+    public String getPrettyName() {
         return prittyName;
     }
 }

--- a/api/src/main/java/org/eclipse/daanse/olap/api/element/HideMemberCondition.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/element/HideMemberCondition.java
@@ -18,9 +18,19 @@ public enum HideMemberCondition {
 
 	NEVER, IF_BLANK_NAME, IF_PARENTS_NAME;
 
+    /**
+     * Accepts both the enum-constant style ("IF_BLANK_NAME") and the mapping
+     * literal style ("IfBlankName"); unknown values fail fast instead of
+     * silently disabling raggedness.
+     */
     public static HideMemberCondition fromValue(String v) {
+        if (v == null || v.isBlank()) {
+            return NEVER;
+        }
+        String normalized = v.replace("_", "");
         return Stream.of(HideMemberCondition.values())
-                .filter(e -> (e.toString().equalsIgnoreCase(v)))
-                .findFirst().orElse(NEVER);
+                .filter(e -> e.name().replace("_", "").equalsIgnoreCase(normalized))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown HideMemberCondition: " + v));
 	}
 }

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/ArgumentBinding.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/ArgumentBinding.java
@@ -1,0 +1,25 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import org.eclipse.daanse.olap.api.DataType;
+
+/**
+ * Binding of one call argument to one declared parameter of the matched
+ * overload. With repeat groups the same parameter index can be bound by
+ * several arguments.
+ */
+public record ArgumentBinding(int argumentIndex, int parameterIndex, DataType argumentCategory,
+        DataType parameterCategory, int conversionCost) {
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/CandidateReport.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/CandidateReport.java
@@ -1,0 +1,21 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import java.util.Optional;
+
+/** One resolver's outcome while resolving a call. */
+public record CandidateReport(FunctionResolver resolver, Optional<FunctionResolutionResult> result,
+        Optional<String> rejectionReason) {
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionInterface.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionInterface.java
@@ -1,0 +1,68 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import org.eclipse.daanse.olap.api.DataType;
+
+/**
+ * Logical classification of a function as exposed through the XMLA
+ * MDSCHEMA_FUNCTIONS INTERFACE_NAME column. The default classification is
+ * derived from the return category via {@link #derivedFrom(DataType)};
+ * functions whose semantic category differs (e.g. Filter returns a set but is
+ * a FILTER function) declare an explicit value.
+ */
+public enum FunctionInterface {
+
+    DATETIME,
+    LOGICAL,
+    FILTER,
+    NAVIGATION,
+    STATISTICAL,
+    STRING,
+    NUMERIC,
+    SET,
+    TUPLE,
+    MEMBER,
+    LEVEL,
+    HIERARCHY,
+    DIMENSION,
+    ARRAY,
+    SUBCUBE,
+    METADATA,
+    KPI,
+    UDF,
+    VALUE,
+    OTHER;
+
+    public static FunctionInterface derivedFrom(DataType returnCategory) {
+        if (returnCategory == null) {
+            return OTHER;
+        }
+        return switch (returnCategory) {
+        case NUMERIC, INTEGER -> NUMERIC;
+        case LOGICAL -> LOGICAL;
+        case STRING -> STRING;
+        case SET -> SET;
+        case MEMBER -> MEMBER;
+        case DATE_TIME -> DATETIME;
+        case TUPLE -> TUPLE;
+        case LEVEL -> LEVEL;
+        case HIERARCHY -> HIERARCHY;
+        case DIMENSION -> DIMENSION;
+        case ARRAY -> ARRAY;
+        case VALUE -> VALUE;
+        default -> OTHER;
+        };
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionMetaData.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionMetaData.java
@@ -14,7 +14,13 @@
 
 package org.eclipse.daanse.olap.api.function;
 
+import java.util.Optional;
+
+import org.eclipse.daanse.mdx.model.api.expression.operation.AmpersandQuotedPropertyOperationAtom;
+import org.eclipse.daanse.mdx.model.api.expression.operation.MethodOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
+import org.eclipse.daanse.mdx.model.api.expression.operation.PlainPropertyOperationAtom;
+import org.eclipse.daanse.mdx.model.api.expression.operation.QuotedPropertyOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
 
 public interface FunctionMetaData {
@@ -29,4 +35,89 @@ public interface FunctionMetaData {
 
     FunctionParameter[] parameters();
 
+    /** Logical classification, MDSCHEMA_FUNCTIONS INTERFACE_NAME. */
+    default FunctionInterface functionInterface() {
+        return FunctionInterface.derivedFrom(returnCategory());
+    }
+
+    /** MDSCHEMA_FUNCTIONS ORIGIN. */
+    default FunctionOrigin origin() {
+        return FunctionOrigin.MSOLAP;
+    }
+
+    /** Implementing library, MDSCHEMA_FUNCTIONS LIBRARY_NAME; set for UDF libraries. */
+    default Optional<String> libraryName() {
+        return Optional.empty();
+    }
+
+    /** Display name, MDSCHEMA_FUNCTIONS CAPTION. */
+    default String caption() {
+        return operationAtom().name();
+    }
+
+    /** Bitmask, MDSCHEMA_FUNCTIONS DIRECTQUERY_PUSHABLE; 0 = not declared. */
+    default int directQueryPushable() {
+        return 0;
+    }
+
+    /** Bitmask, MDSCHEMA_FUNCTIONS VISUAL_CALCULATIONS_INFO; 0 = not declared. */
+    default int visualCalculationsInfo() {
+        return 0;
+    }
+
+    /**
+     * Stable locale-independent key for localized texts. Type overloads that
+     * need distinct texts override with a suffixed key.
+     */
+    default String textKey() {
+        return operationAtom().name();
+    }
+
+    /**
+     * MDSCHEMA_FUNCTIONS OBJECT column: the type of object this function is
+     * called on — the first parameter's type for method and property syntax,
+     * empty otherwise.
+     */
+    default Optional<DataType> callingObject() {
+        OperationAtom atom = operationAtom();
+        boolean onObject = atom instanceof MethodOperationAtom || atom instanceof PlainPropertyOperationAtom
+                || atom instanceof QuotedPropertyOperationAtom
+                || atom instanceof AmpersandQuotedPropertyOperationAtom;
+        FunctionParameter[] params = parameters();
+        if (onObject && params != null && params.length > 0) {
+            return Optional.of(params[0].dataType());
+        }
+        return Optional.empty();
+    }
+
+    /** Minimum number of arguments: non-optional, non-skippable parameters, repeat groups counted once. */
+    default int minArity() {
+        int min = 0;
+        int countedGroup = -1;
+        for (FunctionParameter parameter : parameters()) {
+            if (parameter.optional() || parameter.skippable()) {
+                continue;
+            }
+            int group = parameter.repeatGroup();
+            if (group > 0) {
+                if (group == countedGroup) {
+                    continue;
+                }
+                countedGroup = group;
+            }
+            min++;
+        }
+        return min;
+    }
+
+    /** Maximum number of arguments; {@link Integer#MAX_VALUE} if any parameter is repeatable. */
+    default int maxArity() {
+        FunctionParameter[] params = parameters();
+        for (FunctionParameter parameter : params) {
+            if (parameter.repeatable()) {
+                return Integer.MAX_VALUE;
+            }
+        }
+        return params.length;
+    }
 }

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionOrigin.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionOrigin.java
@@ -1,0 +1,40 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+/**
+ * Origin of a function as exposed through the XMLA MDSCHEMA_FUNCTIONS ORIGIN
+ * column.
+ */
+public enum FunctionOrigin {
+
+    /** Built-in multidimensional function. */
+    MSOLAP(1),
+    /** User-defined function. */
+    UDF(2),
+    /** Relational function. */
+    RELATIONAL(3),
+    /** Scalar function. */
+    SCALAR(4);
+
+    private final int value;
+
+    FunctionOrigin(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionParameter.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionParameter.java
@@ -19,6 +19,21 @@ import java.util.Optional;
 
 import org.eclipse.daanse.olap.api.DataType;
 
+/**
+ * Declared parameter of a function.
+ *
+ * <p>Flag semantics (matching the XMLA MDSCHEMA_FUNCTIONS PARAMETERINFO
+ * rowset):
+ * <ul>
+ * <li>{@link #optional()} — the argument may be absent; all following
+ * non-skippable parameters must then be absent too (trailing optional).</li>
+ * <li>{@link #skippable()} — the argument may be omitted even when subsequent
+ * arguments are present.</li>
+ * <li>{@link #repeatGroup()} — parameters sharing a repeat group &gt; 0 repeat
+ * together as a unit; a group whose first parameter is optional may occur zero
+ * times. A single repeatable parameter forms its own group.</li>
+ * </ul>
+ */
 public interface FunctionParameter {
 
     DataType dataType();
@@ -29,4 +44,23 @@ public interface FunctionParameter {
 
     Optional<List<String>> reservedWords();
 
+    /** The argument may be absent (trailing optional). */
+    default boolean optional() {
+        return false;
+    }
+
+    /** Multiple values may be specified for this parameter. */
+    default boolean repeatable() {
+        return false;
+    }
+
+    /** Index of the repeat group; 0 = not repeated. */
+    default int repeatGroup() {
+        return 0;
+    }
+
+    /** The argument may be omitted even when later arguments are present. */
+    default boolean skippable() {
+        return false;
+    }
 }

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionResolutionResult.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionResolutionResult.java
@@ -1,0 +1,42 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import java.util.List;
+
+/**
+ * Successful match of a resolver: the chosen definition, the declared overload
+ * that matched, the argument-to-parameter bindings and the conversions needed.
+ */
+public interface FunctionResolutionResult {
+
+    FunctionDefinition definition();
+
+    /** The declared overload that matched. */
+    FunctionMetaData matchedMetaData();
+
+    /** Per-argument trace; may be empty for hand-written resolvers. */
+    List<ArgumentBinding> bindings();
+
+    List<FunctionResolver.Conversion> conversions();
+
+    /** Total conversion cost; used by the validator to arbitrate between resolvers. */
+    default int cost() {
+        int cost = 0;
+        for (FunctionResolver.Conversion conversion : conversions()) {
+            cost += conversion.getCost();
+        }
+        return cost;
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionResolver.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionResolver.java
@@ -32,6 +32,7 @@
 package org.eclipse.daanse.olap.api.function;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.query.Validator;
@@ -47,23 +48,18 @@ public interface FunctionResolver {
 
     /**
      * Given a particular set of arguments the function is applied to, returns the
-     * correct overloaded form of the function.
+     * correct overloaded form of the function together with the matched overload,
+     * the argument bindings and the implicit conversions performed. If several
+     * resolvers match, the validator chooses the one whose result has the lowest
+     * conversion cost.
      *
+     * @param args      Expressions which this function call is applied to.
+     * @param validator Validator
      *
-     * The method adds an item to conversions every time it performs an implicit
-     * type-conversion. If there are several candidate functions with the same
-     * signature, the validator will choose the one which used the fewest implicit
-     * conversions.
-     *
-     *
-     * @param args        Expressions which this function call is applied to.
-     * @param validator   Validator
-     * @param conversions List of implicit conversions performed (out)
-     *
-     * @return The function definition which matches these arguments, or null if no
-     *         function definition that this resolver knows about matches.
+     * @return The match, or empty if no overload this resolver knows about
+     *         matches.
      */
-    FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions);
+    Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator);
 
     /**
      * iIndicated whether a argument with a given positionOfArgument must be a

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionTextProvider.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionTextProvider.java
@@ -1,0 +1,33 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Supplies localized {@link FunctionTexts} for function text keys. Multiple
+ * providers may be registered (OSGi service, ranked); each language or source
+ * can contribute its own provider.
+ */
+public interface FunctionTextProvider {
+
+    /**
+     * @param functionKey {@link FunctionMetaData#textKey()}
+     * @param locale      requested locale, never null
+     * @return texts for exactly this locale (no fallback inside the provider),
+     *         empty if this provider has nothing for the key/locale pair
+     */
+    Optional<FunctionTexts> texts(String functionKey, Locale locale);
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionTextService.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionTextService.java
@@ -1,0 +1,26 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import java.util.Locale;
+
+/**
+ * Resolves localized function texts with a fallback chain: exact locale →
+ * language → inline default texts of the metadata. Without any registered
+ * {@link FunctionTextProvider} the result equals the inline texts.
+ */
+public interface FunctionTextService {
+
+    ResolvedFunctionTexts resolve(FunctionMetaData functionMetaData, Locale locale);
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionTexts.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/FunctionTexts.java
@@ -1,0 +1,36 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Localized texts for one function, keyed by {@link FunctionMetaData#textKey()}.
+ * Every field is optional; absent fields fall back to the next provider or the
+ * inline default texts of the metadata.
+ *
+ * @param parameters localized parameter texts keyed by the canonical parameter
+ *                   name ({@link FunctionParameter#name()})
+ */
+public record FunctionTexts(
+        Optional<String> description,
+        Optional<String> caption,
+        Optional<String> example,
+        Optional<String> remarks,
+        Map<String, ParameterTexts> parameters) {
+
+    public record ParameterTexts(Optional<String> displayName, Optional<String> description) {
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/ResolutionExplanation.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/ResolutionExplanation.java
@@ -1,0 +1,32 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
+
+/**
+ * Trace of one overload resolution: every considered resolver with its outcome
+ * and the minimum-cost matches. Resolution succeeds iff there is exactly one
+ * best match.
+ */
+public record ResolutionExplanation(OperationAtom operationAtom, String signature,
+        List<CandidateReport> candidates, List<FunctionResolutionResult> bestMatches) {
+
+    public Optional<FunctionResolutionResult> winner() {
+        return bestMatches.size() == 1 ? Optional.of(bestMatches.get(0)) : Optional.empty();
+    }
+}

--- a/api/src/main/java/org/eclipse/daanse/olap/api/function/ResolvedFunctionTexts.java
+++ b/api/src/main/java/org/eclipse/daanse/olap/api/function/ResolvedFunctionTexts.java
@@ -1,0 +1,33 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.api.function;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Fully resolved texts for one function and locale: description and caption are
+ * always present (falling back to the inline metadata texts), parameter texts
+ * are keyed by canonical parameter name.
+ */
+public record ResolvedFunctionTexts(
+        String description,
+        String caption,
+        Optional<String> example,
+        Optional<String> remarks,
+        Map<String, ResolvedParameterTexts> parameters) {
+
+    public record ResolvedParameterTexts(String displayName, Optional<String> description) {
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/common/Util.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/common/Util.java
@@ -2106,12 +2106,10 @@ public class Util {
                 // conversions are necessary.
                 List<FunctionResolver> resolvers = functionService.getResolvers(operationAtom);
                 final FunctionResolver resolver = resolvers.get(0);
-                final List<FunctionResolver.Conversion> conversionList =
-                    new ArrayList<>();
-                final FunctionDefinition def =
-                    resolver.resolve(args, this, conversionList);
-                assert conversionList.isEmpty();
-                return def;
+                return resolver.resolve(args, this).map(result -> {
+                    assert result.conversions().isEmpty();
+                    return result.definition();
+                }).orElse(null);
             }
 
             @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/common/ValidatorImpl.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/common/ValidatorImpl.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.ParenthesesOperationAtom;
@@ -39,9 +40,12 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.Parameter;
 import org.eclipse.daanse.olap.api.catalog.CatalogReader;
 import org.eclipse.daanse.olap.api.exception.OlapRuntimeException;
+import org.eclipse.daanse.olap.api.function.CandidateReport;
 import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.function.FunctionService;
+import org.eclipse.daanse.olap.api.function.ResolutionExplanation;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.query.component.Formula;
@@ -219,83 +223,75 @@ public abstract class ValidatorImpl implements Validator {
         Expression[] args,
         OperationAtom operationAtom)
     {
-        // Compute signature first. It makes debugging easier.
-		final String signature = FunctionPrinter.getSignature(operationAtom, DataType.UNKNOWN,
-				Expressions.categoriesOf(args));
-
-        // Resolve function by its upper-case name first.  If there is only one
-        // function with that name, stop immediately.  If there is more than
-        // function, use some custom method, which generally involves looking
-        // at the type of one of its arguments.
-        List<FunctionResolver> resolvers = functionService.getResolvers(operationAtom);
-        assert resolvers != null;
-
-        final List<FunctionResolver.Conversion> conversionList =
-            new ArrayList<>();
-        int minConversionCost = Integer.MAX_VALUE;
-        List<FunctionDefinition> matchDefs = new ArrayList<>();
-        List<FunctionResolver.Conversion> matchConversionList = null;
-        for (FunctionResolver resolver : resolvers) {
-            conversionList.clear();
-            FunctionDefinition def = resolver.resolve(args, this, conversionList);
-            if (def != null) {
-                int conversionCost = sumConversionCost(conversionList);
-                if (conversionCost < minConversionCost) {
-                    minConversionCost = conversionCost;
-                    matchDefs.clear();
-                    matchDefs.add(def);
-                    matchConversionList =
-                        new ArrayList<>(conversionList);
-                } else if (conversionCost == minConversionCost) {
-                    matchDefs.add(def);
-                } else {
-                    // ignore this match -- it required more coercions than
-                    // other overloadings we've seen
-                }
-            }
-        }
-        switch (matchDefs.size()) {
+        ResolutionExplanation explanation = explainDef(args, operationAtom);
+        List<FunctionResolutionResult> bestMatches = explanation.bestMatches();
+        switch (bestMatches.size()) {
         case 0:
             throw new OlapRuntimeException(MessageFormat.format(noFunctionMatchesSignature,
-                signature));
+                explanation.signature()));
         case 1:
             break;
         default:
             final StringBuilder buf = new StringBuilder();
-            for (FunctionDefinition matchDef : matchDefs) {
+            for (FunctionResolutionResult match : bestMatches) {
                 if (buf.length() > 0) {
                     buf.append(", ");
                 }
-                buf.append(matchDef.getSignature());
+                buf.append(match.definition().getSignature());
             }
             throw new OlapRuntimeException(MessageFormat.format(
                 moreThanOneFunctionMatchesSignature,
-                    signature,
+                    explanation.signature(),
                     buf.toString()));
         }
 
-        final FunctionDefinition matchDef = matchDefs.get(0);
-        for (FunctionResolver.Conversion conversion : matchConversionList) {
+        final FunctionResolutionResult winner = bestMatches.get(0);
+        for (FunctionResolver.Conversion conversion : winner.conversions()) {
             conversion.checkValid();
             conversion.apply(this, Arrays.asList(args));
         }
 
-        return matchDef;
+        return winner.definition();
+    }
+
+    /**
+     * Side-effect-free resolution trace: every resolver's outcome and the
+     * minimum-cost matches. Used by getDef; also the entry point for
+     * diagnosing why a call resolved (or failed to resolve) the way it did.
+     */
+    public ResolutionExplanation explainDef(Expression[] args, OperationAtom operationAtom) {
+        final String signature = FunctionPrinter.getSignature(operationAtom, DataType.UNKNOWN,
+                Expressions.categoriesOf(args));
+
+        List<FunctionResolver> resolvers = functionService.getResolvers(operationAtom);
+        assert resolvers != null;
+
+        List<CandidateReport> candidates = new ArrayList<>();
+        int minConversionCost = Integer.MAX_VALUE;
+        List<FunctionResolutionResult> bestMatches = new ArrayList<>();
+        for (FunctionResolver resolver : resolvers) {
+            Optional<FunctionResolutionResult> result = resolver.resolve(args, this);
+            if (result.isPresent()) {
+                candidates.add(new CandidateReport(resolver, result, Optional.empty()));
+                int conversionCost = result.get().cost();
+                if (conversionCost < minConversionCost) {
+                    minConversionCost = conversionCost;
+                    bestMatches.clear();
+                    bestMatches.add(result.get());
+                } else if (conversionCost == minConversionCost) {
+                    bestMatches.add(result.get());
+                }
+            } else {
+                candidates.add(new CandidateReport(resolver, Optional.empty(),
+                        Optional.of("no overload matches")));
+            }
+        }
+        return new ResolutionExplanation(operationAtom, signature, candidates, bestMatches);
     }
 
     @Override
 	public boolean alwaysResolveFunDef() {
         return false;
-    }
-
-    private int sumConversionCost(
-        List<FunctionResolver.Conversion> conversionList)
-    {
-        int cost = 0;
-        for (FunctionResolver.Conversion conversion : conversionList) {
-            cost += conversion.getCost();
-        }
-        return cost;
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/fun/FunUtil.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/fun/FunUtil.java
@@ -1292,7 +1292,8 @@ public class FunUtil extends Util {
       && query != null
       && query.nativeCrossJoinVirtualCube() ) {
     	DataType[] paramCategories = funDef.getFunctionMetaData().parameterDataTypes();
-      if ( paramCategories.length > 0 ) {
+      // declared parameters can exceed the actual arguments (optional parameters)
+      if ( paramCategories.length > 0 && args.length > 0 ) {
         final DataType cat0 = paramCategories[ 0 ];
         final Expression arg0 = args[ 0 ];
         switch ( cat0 ) {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/FunctionMetaDataR.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/FunctionMetaDataR.java
@@ -14,17 +14,72 @@
 
 package org.eclipse.daanse.olap.function.core;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionOrigin;
 
-public record FunctionMetaDataR(OperationAtom operationAtom, String description,
-        DataType returnCategory, FunctionParameterR[] parameters) implements FunctionMetaData {
+public record FunctionMetaDataR(OperationAtom operationAtom, String description, DataType returnCategory,
+        FunctionParameterR[] parameters, FunctionInterface functionInterface, FunctionOrigin origin,
+        Optional<String> libraryName, Optional<String> captionOverride, Optional<String> textKeyOverride,
+        int directQueryPushable, int visualCalculationsInfo) implements FunctionMetaData {
 
+    public FunctionMetaDataR(OperationAtom operationAtom, String description, DataType returnCategory,
+            FunctionParameterR[] parameters) {
+        this(operationAtom, description, returnCategory, parameters, FunctionInterface.derivedFrom(returnCategory),
+                FunctionOrigin.MSOLAP, Optional.empty(), Optional.empty(), Optional.empty(), 0, 0);
+    }
+
+    public static FunctionMetaDataR of(OperationAtom operationAtom, String description, DataType returnCategory,
+            FunctionParameterR... parameters) {
+        return new FunctionMetaDataR(operationAtom, description, returnCategory, parameters);
+    }
+
+    @Override
     public DataType[] parameterDataTypes() {
         return Stream.of(parameters()).map(FunctionParameterR::dataType).toArray(DataType[]::new);
     }
 
+    @Override
+    public String caption() {
+        return captionOverride.orElseGet(() -> operationAtom().name());
+    }
+
+    @Override
+    public String textKey() {
+        return textKeyOverride.orElseGet(() -> operationAtom().name());
+    }
+
+    public FunctionMetaDataR interfaceName(FunctionInterface fi) {
+        return new FunctionMetaDataR(operationAtom, description, returnCategory, parameters, fi, origin, libraryName,
+                captionOverride, textKeyOverride, directQueryPushable, visualCalculationsInfo);
+    }
+
+    public FunctionMetaDataR caption(String caption) {
+        return new FunctionMetaDataR(operationAtom, description, returnCategory, parameters, functionInterface, origin,
+                libraryName, Optional.ofNullable(caption), textKeyOverride, directQueryPushable,
+                visualCalculationsInfo);
+    }
+
+    public FunctionMetaDataR origin(FunctionOrigin functionOrigin) {
+        return new FunctionMetaDataR(operationAtom, description, returnCategory, parameters, functionInterface,
+                functionOrigin, libraryName, captionOverride, textKeyOverride, directQueryPushable,
+                visualCalculationsInfo);
+    }
+
+    public FunctionMetaDataR library(String library) {
+        return new FunctionMetaDataR(operationAtom, description, returnCategory, parameters, functionInterface, origin,
+                Optional.ofNullable(library), captionOverride, textKeyOverride, directQueryPushable,
+                visualCalculationsInfo);
+    }
+
+    public FunctionMetaDataR withTextKey(String textKey) {
+        return new FunctionMetaDataR(operationAtom, description, returnCategory, parameters, functionInterface, origin,
+                libraryName, captionOverride, Optional.ofNullable(textKey), directQueryPushable,
+                visualCalculationsInfo);
+    }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/FunctionParameterR.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/FunctionParameterR.java
@@ -18,22 +18,84 @@ import java.util.Optional;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.function.FunctionParameter;
 
-public record FunctionParameterR(DataType dataType, Optional<String> name, Optional<String> description, Optional<List<String>> reservedWords) implements FunctionParameter{
+public record FunctionParameterR(DataType dataType, Optional<String> name, Optional<String> description,
+        Optional<List<String>> reservedWords, boolean optional, boolean repeatable, int repeatGroup,
+        boolean skippable) implements FunctionParameter {
 
-	public FunctionParameterR(DataType dataType) {
-		this(dataType, Optional.empty(), Optional.empty(), Optional.empty());
-	}
+    public FunctionParameterR(DataType dataType, Optional<String> name, Optional<String> description,
+            Optional<List<String>> reservedWords) {
+        this(dataType, name, description, reservedWords, false, false, 0, false);
+    }
 
-	public FunctionParameterR(DataType dataType, String name) {
-		this(dataType, Optional.ofNullable(name), Optional.empty(), Optional.empty());
-	}
+    public FunctionParameterR(DataType dataType) {
+        this(dataType, Optional.empty(), Optional.empty(), Optional.empty());
+    }
 
-	public FunctionParameterR(DataType dataType, String name, String description) {
-		this(dataType, Optional.ofNullable(name), Optional.ofNullable(description), Optional.empty());
-	}
-	
+    public FunctionParameterR(DataType dataType, String name) {
+        this(dataType, Optional.ofNullable(name), Optional.empty(), Optional.empty());
+    }
+
+    public FunctionParameterR(DataType dataType, String name, String description) {
+        this(dataType, Optional.ofNullable(name), Optional.ofNullable(description), Optional.empty());
+    }
+
     public FunctionParameterR(DataType dataType, String name, Optional<List<String>> reservedWords) {
         this(dataType, Optional.ofNullable(name), Optional.empty(), reservedWords);
     }
 
+    /** Factory with the canonical vocabulary name derived from the data type. */
+    public static FunctionParameterR param(DataType dataType) {
+        return param(dataType, canonicalNameOf(dataType));
+    }
+
+    public static FunctionParameterR param(DataType dataType, String name) {
+        return new FunctionParameterR(dataType, Optional.ofNullable(name), Optional.empty(), Optional.empty(), false,
+                false, 0, false);
+    }
+
+    public FunctionParameterR asOptional() {
+        return new FunctionParameterR(dataType, name, description, reservedWords, true, repeatable, repeatGroup,
+                skippable);
+    }
+
+    public FunctionParameterR asSkippable() {
+        return new FunctionParameterR(dataType, name, description, reservedWords, optional, repeatable, repeatGroup,
+                true);
+    }
+
+    public FunctionParameterR repeatable(int group) {
+        return new FunctionParameterR(dataType, name, description, reservedWords, optional, true, group, skippable);
+    }
+
+    public FunctionParameterR describedAs(String parameterDescription) {
+        return new FunctionParameterR(dataType, name, Optional.ofNullable(parameterDescription), reservedWords,
+                optional, repeatable, repeatGroup, skippable);
+    }
+
+    public FunctionParameterR reserved(String... words) {
+        return new FunctionParameterR(dataType, name, description, Optional.of(List.of(words)), optional, repeatable,
+                repeatGroup, skippable);
+    }
+
+    /** Canonical parameter name per data type, aligned with the MDX reference. */
+    public static String canonicalNameOf(DataType dataType) {
+        return switch (dataType) {
+        case SET -> "Set";
+        case MEMBER -> "Member";
+        case TUPLE -> "Tuple";
+        case NUMERIC -> "Numeric_Expression";
+        case INTEGER -> "Index";
+        case STRING -> "String_Expression";
+        case LOGICAL -> "Logical_Expression";
+        case LEVEL -> "Level";
+        case HIERARCHY -> "Hierarchy";
+        case DIMENSION -> "Dimension";
+        case SYMBOL -> "Flag";
+        case VALUE -> "Value_Expression";
+        case DATE_TIME -> "DateTime";
+        case CUBE -> "Cube";
+        case ARRAY -> "Array";
+        default -> "Expression";
+        };
+    }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/FunctionPrinter.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/FunctionPrinter.java
@@ -277,7 +277,7 @@ public class FunctionPrinter {
 	}
 
 	private static String getTypeDescription(DataType type) {
-		return new StringBuilder("<").append(type.getPrittyName()).append(">").toString();
+		return new StringBuilder("<").append(type.getPrettyName()).append(">").toString();
 	}
 
 	private static String getTypeDescriptionCommaList(DataType[] types, int start) {
@@ -287,7 +287,7 @@ public class FunctionPrinter {
 			if (i > start) {
 				sb.append(", ");
 			}
-			sb.append("<").append(types[i].getPrittyName()).append(">");
+			sb.append("<").append(types[i].getPrettyName()).append(">");
 		}
 		return sb.toString();
 	}

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/FunctionServiceImpl.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/FunctionServiceImpl.java
@@ -79,7 +79,7 @@ public class FunctionServiceImpl implements FunctionService {
 	@Override
 	public void removeResolver(FunctionResolver resolver) {
 
-		this.resolvers.add(resolver);
+		this.resolvers.remove(resolver);
 		reInitialize();
 	}
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/AbstractFunctionDefinitionMultiResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/AbstractFunctionDefinitionMultiResolver.java
@@ -14,9 +14,12 @@
 package org.eclipse.daanse.olap.function.core.resolver;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
+import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 
 public class AbstractFunctionDefinitionMultiResolver extends AbstractMetaDataMultiResolver {
@@ -29,13 +32,34 @@ public class AbstractFunctionDefinitionMultiResolver extends AbstractMetaDataMul
 	}
 
 	@Override
+	public Optional<FunctionResolutionResult> resolve(Expression[] expressions, Validator validator) {
+		for (FunctionDefinition functionDefinition : functionDefinitions) {
+			FunctionMetaData functionMetaData = functionDefinition.getFunctionMetaData();
+			Optional<FunctionMetaDataMatcher.Match> match = FunctionMetaDataMatcher.match(functionMetaData,
+					expressions, validator);
+			if (match.isPresent()) {
+				// createFunDef stays the hook for resolvers that need a fresh,
+				// per-call definition (e.g. NativizeSet holds per-call state).
+				FunctionDefinition def = createFunDef(expressions, functionMetaData, functionMetaData);
+				if (def != null) {
+					return Optional.of(new FunctionResolutionResultR(def, functionMetaData,
+							match.get().bindings(), match.get().conversions()));
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	@Override
 	protected FunctionDefinition createFunDef(Expression[] args, FunctionMetaData functionMetaData,
 			FunctionMetaData fmdTarget) {
 
 		if (functionMetaData == null) {
 			return null;
 		}
-		return functionDefinitions.stream().filter(fd -> fd.getFunctionMetaData().equals(functionMetaData)).findAny()
+		// identity, not equals: the metadata instance comes from the matched
+		// definition itself
+		return functionDefinitions.stream().filter(fd -> fd.getFunctionMetaData() == functionMetaData).findAny()
 				.orElse(null);
 	}
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/AbstractMetaDataMultiResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/AbstractMetaDataMultiResolver.java
@@ -15,17 +15,17 @@ package org.eclipse.daanse.olap.function.core.resolver;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
-import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.exception.OlapRuntimeException;
 import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
-import org.eclipse.daanse.olap.function.core.FunctionParameterR;
 import org.eclipse.daanse.olap.query.base.Expressions;
 
 public abstract class AbstractMetaDataMultiResolver implements FunctionResolver {
@@ -52,25 +52,23 @@ public abstract class AbstractMetaDataMultiResolver implements FunctionResolver 
 	}
 
 	@Override
-	public FunctionDefinition resolve(Expression[] expressions, Validator validator, List<Conversion> conversions) {
-		outer: for (FunctionMetaData functionMetaData : fmds) {
-			DataType[] parameterTypes = functionMetaData.parameterDataTypes();
-			if (parameterTypes.length != expressions.length) {
+	public Optional<FunctionResolutionResult> resolve(Expression[] expressions, Validator validator) {
+		for (FunctionMetaData functionMetaData : fmds) {
+			Optional<FunctionMetaDataMatcher.Match> match = FunctionMetaDataMatcher.match(functionMetaData,
+					expressions, validator);
+			if (match.isEmpty()) {
 				continue;
 			}
-			conversions.clear();
-			for (int i = 0; i < expressions.length; i++) {
-				if (!validator.canConvert(i, expressions[i], parameterTypes[i], conversions)) {
-					continue outer;
-				}
-			}
-
-			FunctionParameterR[] paramDataTypesOfExpr = Expressions.functionParameterOf(expressions);
 			FunctionMetaData fmdTarget = new FunctionMetaDataR(operationAtom, functionMetaData.description(),
-					functionMetaData.returnCategory(), paramDataTypesOfExpr);
-			return createFunDef(expressions, functionMetaData, fmdTarget);
+					functionMetaData.returnCategory(),
+					Expressions.boundParametersOf(expressions, functionMetaData, match.get().bindings()));
+			FunctionDefinition def = createFunDef(expressions, functionMetaData, fmdTarget);
+			if (def != null) {
+				return Optional.of(new FunctionResolutionResultR(def, functionMetaData, match.get().bindings(),
+						match.get().conversions()));
+			}
 		}
-		return null;
+		return Optional.empty();
 	}
 
 	@Override
@@ -81,8 +79,7 @@ public abstract class AbstractMetaDataMultiResolver implements FunctionResolver 
 	@Override
 	public boolean requiresScalarExpressionOnArgument(int k) {
 		for (FunctionMetaData fmd : fmds) {
-			DataType[] parameterTypes = fmd.parameterDataTypes();
-			if ((k < parameterTypes.length) && parameterTypes[k] == DataType.SET) {
+			if (FunctionMetaDataMatcher.setPossibleAt(fmd, k)) {
 				return false;
 			}
 		}

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/FunctionMetaDataMatcher.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/FunctionMetaDataMatcher.java
@@ -1,0 +1,172 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.function.core.resolver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.ArgumentBinding;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionParameter;
+import org.eclipse.daanse.olap.api.function.FunctionResolver.Conversion;
+import org.eclipse.daanse.olap.api.query.Validator;
+import org.eclipse.daanse.olap.api.query.component.Expression;
+
+/**
+ * Matches one declared {@link FunctionMetaData} against actual call arguments,
+ * honoring the parameter flags optional, skippable and repeatGroup.
+ *
+ * <p>The walk is positional and greedy: a parameter that can bind the current
+ * argument binds it; on a conversion failure an optional or skippable parameter
+ * is skipped without consuming the argument. A repeat group is matched
+ * unit-by-unit while enough arguments remain for the parameters after the
+ * group. Without any flags this reduces to the classic exact-arity,
+ * per-position canConvert check.
+ */
+public final class FunctionMetaDataMatcher {
+
+    private FunctionMetaDataMatcher() {
+    }
+
+    public record Match(List<ArgumentBinding> bindings, List<Conversion> conversions) {
+    }
+
+    public static Optional<Match> match(FunctionMetaData functionMetaData, Expression[] args, Validator validator) {
+        FunctionParameter[] params = functionMetaData.parameters();
+        int argCount = args.length;
+        if (argCount < functionMetaData.minArity() || argCount > functionMetaData.maxArity()) {
+            return Optional.empty();
+        }
+
+        List<Conversion> conversions = new ArrayList<>();
+        List<ArgumentBinding> bindings = new ArrayList<>();
+        int i = 0;
+        int j = 0;
+        while (j < params.length) {
+            FunctionParameter parameter = params[j];
+            int group = parameter.repeatGroup();
+            if (group > 0) {
+                int groupEnd = j;
+                while (groupEnd < params.length && params[groupEnd].repeatGroup() == group) {
+                    groupEnd++;
+                }
+                int minAfter = minArityOfRange(params, groupEnd);
+                boolean requiredGroup = !params[j].optional();
+                int units = 0;
+                while (i < argCount - minAfter) {
+                    int saveArg = i;
+                    int saveBindings = bindings.size();
+                    int saveConversions = conversions.size();
+                    boolean unitOk = true;
+                    boolean consumed = false;
+                    for (int g = j; g < groupEnd && unitOk; g++) {
+                        FunctionParameter groupParameter = params[g];
+                        if (i < argCount - minAfter
+                                && tryBind(i, args, g, groupParameter, validator, conversions, bindings)) {
+                            i++;
+                            consumed = true;
+                        } else if (!groupParameter.skippable() && !groupParameter.optional()) {
+                            unitOk = false;
+                        }
+                    }
+                    if (!unitOk || !consumed) {
+                        i = saveArg;
+                        truncate(bindings, saveBindings);
+                        truncate(conversions, saveConversions);
+                        break;
+                    }
+                    units++;
+                }
+                if (units == 0 && requiredGroup) {
+                    return Optional.empty();
+                }
+                j = groupEnd;
+            } else {
+                if (i < argCount && tryBind(i, args, j, parameter, validator, conversions, bindings)) {
+                    i++;
+                    j++;
+                } else if (parameter.optional() || parameter.skippable()) {
+                    j++;
+                } else {
+                    return Optional.empty();
+                }
+            }
+        }
+        if (i != argCount) {
+            return Optional.empty();
+        }
+        return Optional.of(new Match(bindings, conversions));
+    }
+
+    /** True when a SET argument is possible at position k for this overload. */
+    public static boolean setPossibleAt(FunctionMetaData functionMetaData, int k) {
+        FunctionParameter[] params = functionMetaData.parameters();
+        boolean flexible = false;
+        for (int idx = 0; idx < params.length; idx++) {
+            FunctionParameter parameter = params[idx];
+            boolean flagged = parameter.optional() || parameter.skippable() || parameter.repeatGroup() > 0;
+            if (parameter.dataType() == DataType.SET) {
+                if (idx == k || (flexible && idx <= k) || (parameter.repeatGroup() > 0 && idx <= k)) {
+                    return true;
+                }
+            }
+            flexible |= flagged;
+        }
+        return false;
+    }
+
+    private static int minArityOfRange(FunctionParameter[] params, int from) {
+        int min = 0;
+        int countedGroup = -1;
+        for (int idx = from; idx < params.length; idx++) {
+            FunctionParameter parameter = params[idx];
+            if (parameter.optional() || parameter.skippable()) {
+                continue;
+            }
+            int group = parameter.repeatGroup();
+            if (group > 0) {
+                if (group == countedGroup) {
+                    continue;
+                }
+                countedGroup = group;
+            }
+            min++;
+        }
+        return min;
+    }
+
+    private static boolean tryBind(int argIndex, Expression[] args, int paramIndex, FunctionParameter parameter,
+            Validator validator, List<Conversion> conversions, List<ArgumentBinding> bindings) {
+        int before = conversions.size();
+        if (!validator.canConvert(argIndex, args[argIndex], parameter.dataType(), conversions)) {
+            truncate(conversions, before);
+            return false;
+        }
+        int cost = 0;
+        for (int c = before; c < conversions.size(); c++) {
+            cost += conversions.get(c).getCost();
+        }
+        bindings.add(new ArgumentBinding(argIndex, paramIndex, args[argIndex].getCategory(), parameter.dataType(),
+                cost));
+        return true;
+    }
+
+    private static void truncate(List<?> list, int size) {
+        while (list.size() > size) {
+            list.remove(list.size() - 1);
+        }
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/FunctionResolutionResultR.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/FunctionResolutionResultR.java
@@ -1,0 +1,31 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.function.core.resolver;
+
+import java.util.List;
+
+import org.eclipse.daanse.olap.api.function.ArgumentBinding;
+import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
+import org.eclipse.daanse.olap.api.function.FunctionResolver.Conversion;
+
+public record FunctionResolutionResultR(FunctionDefinition definition, FunctionMetaData matchedMetaData,
+        List<ArgumentBinding> bindings, List<Conversion> conversions) implements FunctionResolutionResult {
+
+    /** For hand-written resolvers without argument trace. */
+    public static FunctionResolutionResultR of(FunctionDefinition definition, List<Conversion> conversions) {
+        return new FunctionResolutionResultR(definition, definition.getFunctionMetaData(), List.of(), conversions);
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/NonFunctionResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/NonFunctionResolver.java
@@ -13,12 +13,12 @@
  */
 package org.eclipse.daanse.olap.function.core.resolver;
 
-import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
@@ -38,8 +38,8 @@ public class NonFunctionResolver implements FunctionResolver {
     }
 
     @Override
-    public FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions) {
-        return null;
+    public Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator) {
+        return Optional.empty();
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/NullReservedWordsResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/NullReservedWordsResolver.java
@@ -14,10 +14,11 @@
 package org.eclipse.daanse.olap.function.core.resolver;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.EmptyOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
@@ -32,8 +33,8 @@ public class NullReservedWordsResolver implements FunctionResolver {
     }
 
     @Override
-    public FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions) {
-        return null;
+    public Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator) {
+        return Optional.empty();
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/ParametersCheckingFunctionDefinitionResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/resolver/ParametersCheckingFunctionDefinitionResolver.java
@@ -15,11 +15,13 @@
 package org.eclipse.daanse.olap.function.core.resolver;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
@@ -46,22 +48,15 @@ public class ParametersCheckingFunctionDefinitionResolver implements FunctionRes
 	}
 
 	@Override
-	public FunctionDefinition resolve(Expression[] expressions, Validator validator, List<Conversion> conversions) {
-		DataType[] parameterDataTypes = functionDefinition.getFunctionMetaData().parameterDataTypes();
-		if (parameterDataTypes.length != expressions.length) {
-			return null;
+	public Optional<FunctionResolutionResult> resolve(Expression[] expressions, Validator validator) {
+		FunctionMetaData functionMetaData = functionDefinition.getFunctionMetaData();
+		Optional<FunctionMetaDataMatcher.Match> match = FunctionMetaDataMatcher.match(functionMetaData, expressions,
+				validator);
+		if (match.isEmpty() || !checkExpressions(expressions)) {
+			return Optional.empty();
 		}
-
-		for (int i = 0; i < expressions.length; i++) {
-			if (!validator.canConvert(i, expressions[i], parameterDataTypes[i], conversions)) {
-				return null;
-			}
-		}
-
-		if (checkExpressions(expressions)) {
-			return functionDefinition;
-		}
-		return null;
+		return Optional.of(new FunctionResolutionResultR(functionDefinition, functionMetaData,
+				match.get().bindings(), match.get().conversions()));
 	}
 
 	protected boolean checkExpressions(Expression[] expressions) {
@@ -70,8 +65,7 @@ public class ParametersCheckingFunctionDefinitionResolver implements FunctionRes
 
 	@Override
 	public boolean requiresScalarExpressionOnArgument(int k) {
-		DataType[] parameterDataTypes = functionDefinition.getFunctionMetaData().parameterDataTypes();
-		return (k >= parameterDataTypes.length) || (parameterDataTypes[k] != DataType.SET);
+		return !FunctionMetaDataMatcher.setPossibleAt(functionDefinition.getFunctionMetaData(), k);
 	}
 
 	@Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/text/BundledFunctionTextProvider.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/text/BundledFunctionTextProvider.java
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.function.core.text;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import org.eclipse.daanse.olap.api.function.FunctionTextProvider;
+import org.eclipse.daanse.olap.api.function.FunctionTexts;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Ships the bundled translations (functions_&lt;lang&gt;.properties in this
+ * package). Additional languages or sources register their own
+ * {@link FunctionTextProvider}.
+ */
+@Component(service = FunctionTextProvider.class)
+public class BundledFunctionTextProvider implements FunctionTextProvider {
+
+    private final ResourceBundleFunctionTextProvider delegate = new ResourceBundleFunctionTextProvider(
+            "org.eclipse.daanse.olap.function.core.text.functions", BundledFunctionTextProvider.class.getClassLoader());
+
+    @Override
+    public Optional<FunctionTexts> texts(String functionKey, Locale locale) {
+        return delegate.texts(functionKey, locale);
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/text/FunctionTextServiceImpl.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/text/FunctionTextServiceImpl.java
@@ -1,0 +1,119 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.function.core.text;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionParameter;
+import org.eclipse.daanse.olap.api.function.FunctionTextProvider;
+import org.eclipse.daanse.olap.api.function.FunctionTextService;
+import org.eclipse.daanse.olap.api.function.FunctionTexts;
+import org.eclipse.daanse.olap.api.function.ResolvedFunctionTexts;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.component.annotations.ServiceScope;
+
+@Component(service = FunctionTextService.class, scope = ServiceScope.SINGLETON)
+public class FunctionTextServiceImpl implements FunctionTextService {
+
+    private final List<FunctionTextProvider> providers = new ArrayList<>();
+
+    @Reference(service = FunctionTextProvider.class, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    public synchronized void addProvider(FunctionTextProvider provider) {
+        providers.add(provider);
+    }
+
+    public synchronized void removeProvider(FunctionTextProvider provider) {
+        providers.remove(provider);
+    }
+
+    @Override
+    public ResolvedFunctionTexts resolve(FunctionMetaData functionMetaData, Locale locale) {
+        List<FunctionTexts> layers = layersFor(functionMetaData.textKey(), locale);
+
+        String description = firstText(layers, FunctionTexts::description).orElse(functionMetaData.description());
+        String caption = firstText(layers, FunctionTexts::caption).orElse(functionMetaData.caption());
+        Optional<String> example = firstText(layers, FunctionTexts::example);
+        Optional<String> remarks = firstText(layers, FunctionTexts::remarks);
+
+        Map<String, ResolvedFunctionTexts.ResolvedParameterTexts> parameters = new HashMap<>();
+        for (FunctionParameter parameter : functionMetaData.parameters()) {
+            Optional<String> parameterName = parameter.name();
+            if (parameterName.isEmpty()) {
+                continue;
+            }
+            String key = parameterName.get();
+            Optional<String> displayName = firstParameterText(layers, key, FunctionTexts.ParameterTexts::displayName);
+            Optional<String> parameterDescription = firstParameterText(layers, key,
+                    FunctionTexts.ParameterTexts::description);
+            parameters.put(key, new ResolvedFunctionTexts.ResolvedParameterTexts(
+                    displayName.orElseGet(() -> key.replace('_', ' ')),
+                    parameterDescription.or(parameter::description)));
+        }
+        return new ResolvedFunctionTexts(description, caption, example, remarks, Map.copyOf(parameters));
+    }
+
+    /** Layers ordered by precedence: exact locale, then language-only, per provider registration order. */
+    private synchronized List<FunctionTexts> layersFor(String functionKey, Locale locale) {
+        List<FunctionTexts> layers = new ArrayList<>();
+        List<Locale> chain = new ArrayList<>();
+        if (locale != null) {
+            chain.add(locale);
+            if (!locale.getCountry().isEmpty() || !locale.getVariant().isEmpty()) {
+                chain.add(Locale.of(locale.getLanguage()));
+            }
+        }
+        for (Locale l : chain) {
+            for (FunctionTextProvider provider : providers) {
+                provider.texts(functionKey, l).ifPresent(layers::add);
+            }
+        }
+        return layers;
+    }
+
+    private static Optional<String> firstText(List<FunctionTexts> layers,
+            Function<FunctionTexts, Optional<String>> accessor) {
+        for (FunctionTexts layer : layers) {
+            Optional<String> value = accessor.apply(layer);
+            if (value.isPresent()) {
+                return value;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> firstParameterText(List<FunctionTexts> layers, String parameterKey,
+            Function<FunctionTexts.ParameterTexts, Optional<String>> accessor) {
+        for (FunctionTexts layer : layers) {
+            FunctionTexts.ParameterTexts parameterTexts = layer.parameters().get(parameterKey);
+            if (parameterTexts != null) {
+                Optional<String> value = accessor.apply(parameterTexts);
+                if (value.isPresent()) {
+                    return value;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/function/core/text/ResourceBundleFunctionTextProvider.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/core/text/ResourceBundleFunctionTextProvider.java
@@ -1,0 +1,101 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.function.core.text;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.ResourceBundle;
+
+import org.eclipse.daanse.olap.api.function.FunctionTextProvider;
+import org.eclipse.daanse.olap.api.function.FunctionTexts;
+
+/**
+ * {@link FunctionTextProvider} backed by {@link ResourceBundle} properties.
+ *
+ * <p>Key scheme: {@code <textKey>.description|caption|example|remarks} and
+ * {@code <textKey>.param.<parameterName>.displayName|description}.
+ *
+ * <p>Register an instance per bundle (as an OSGi service or via the
+ * {@link FunctionTextServiceImpl}); locale fallback is handled by the service,
+ * therefore this provider only answers for the exact bundle locale.
+ */
+public class ResourceBundleFunctionTextProvider implements FunctionTextProvider {
+
+    private static final String PARAM_SEGMENT = ".param.";
+
+    private final String baseName;
+    private final ClassLoader classLoader;
+
+    public ResourceBundleFunctionTextProvider(String baseName, ClassLoader classLoader) {
+        this.baseName = baseName;
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public Optional<FunctionTexts> texts(String functionKey, Locale locale) {
+        ResourceBundle bundle;
+        try {
+            bundle = ResourceBundle.getBundle(baseName, locale, classLoader,
+                    ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES));
+        } catch (MissingResourceException e) {
+            return Optional.empty();
+        }
+        if (!matches(bundle.getLocale(), locale)) {
+            return Optional.empty();
+        }
+
+        Optional<String> description = read(bundle, functionKey + ".description");
+        Optional<String> caption = read(bundle, functionKey + ".caption");
+        Optional<String> example = read(bundle, functionKey + ".example");
+        Optional<String> remarks = read(bundle, functionKey + ".remarks");
+
+        Map<String, FunctionTexts.ParameterTexts> parameters = new HashMap<>();
+        String prefix = functionKey + PARAM_SEGMENT;
+        for (String key : bundle.keySet()) {
+            if (!key.startsWith(prefix)) {
+                continue;
+            }
+            String rest = key.substring(prefix.length());
+            int dot = rest.lastIndexOf('.');
+            if (dot <= 0) {
+                continue;
+            }
+            String parameterName = rest.substring(0, dot);
+            parameters.computeIfAbsent(parameterName,
+                    p -> new FunctionTexts.ParameterTexts(read(bundle, prefix + p + ".displayName"),
+                            read(bundle, prefix + p + ".description")));
+        }
+
+        if (description.isEmpty() && caption.isEmpty() && example.isEmpty() && remarks.isEmpty()
+                && parameters.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new FunctionTexts(description, caption, example, remarks, Map.copyOf(parameters)));
+    }
+
+    private static boolean matches(Locale bundleLocale, Locale requested) {
+        if (bundleLocale.equals(requested)) {
+            return true;
+        }
+        return bundleLocale.getLanguage().equals(requested.getLanguage()) && bundleLocale.getCountry().isEmpty()
+                && requested.getCountry().isEmpty();
+    }
+
+    private static Optional<String> read(ResourceBundle bundle, String key) {
+        return bundle.containsKey(key) ? Optional.of(bundle.getString(key)) : Optional.empty();
+    }
+}

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/AbstractFunctionDefinition.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/AbstractFunctionDefinition.java
@@ -58,12 +58,12 @@ public abstract class AbstractFunctionDefinition implements FunctionDefinition {
 	public Expression createCall(Validator validator, Expression[] args) {
 		DataType[] categories = functionMetaData.parameterDataTypes();
 
-		if (categories.length != args.length) {
+		if (args.length < functionMetaData.minArity() || args.length > functionMetaData.maxArity()) {
 			throw new IllegalArgumentException("Categories does not match arguments count");
 		}
 
 		for (int i = 0; i < args.length; i++) {
-			args[i] = validateArgument(validator, args, i, categories[i]);
+			args[i] = validateArgument(validator, args, i, i < categories.length ? categories[i] : categories[categories.length - 1]);
 		}
 
 		final Type type = getResultType(validator, args);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/AggregateResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/AggregateResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,15 +29,12 @@ import org.osgi.service.component.annotations.Component;
 public class AggregateResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Aggregate");
     private static String DESCRIPTION = "Returns a calculated value using the appropriate aggregate function, based on the context of the query.";
-    // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(DataType.SET) });
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(DataType.SET),
-                    new FunctionParameterR(DataType.NUMERIC) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC).asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public AggregateResolver() {
-        super(List.of(new AggregateFunDef(functionMetaData), new AggregateFunDef(functionMetaData1)));
+        super(List.of(new AggregateFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/avg/AvgFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/avg/AvgFunDef.java
@@ -17,6 +17,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.calc.base.value.CurrentValueUnknownCalc;
@@ -29,7 +30,7 @@ class AvgFunDef extends AbstractAggregateFunDef {
 
 	static final FunctionMetaData fmd = new FunctionMetaDataR(AvgResolver.operationAtom,
 			"Returns the average value of a numeric expression evaluated over a set.", DataType.NUMERIC,
-			new FunctionParameterR[] { new FunctionParameterR(  DataType.SET ) });
+			new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) }).interfaceName(FunctionInterface.STATISTICAL);
 
 	public AvgFunDef() {
 		super(fmd);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/avg/AvgNumericFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/avg/AvgNumericFunDef.java
@@ -17,6 +17,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -26,7 +27,7 @@ import org.eclipse.daanse.olap.function.def.aggregate.AbstractAggregateFunDef;
 class AvgNumericFunDef extends AbstractAggregateFunDef {
 	static final FunctionMetaData fmd = new FunctionMetaDataR(AvgResolver.operationAtom,
 			"Returns the average value of a numeric expression evaluated over a set.", DataType.NUMERIC,
-			new FunctionParameterR[] { new FunctionParameterR(  DataType.SET ), new FunctionParameterR( DataType.NUMERIC ) });
+			new FunctionParameterR[] { FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.NUMERIC) }).interfaceName(FunctionInterface.STATISTICAL);
 
 	public AvgNumericFunDef() {
 		super(fmd);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/children/AggregateChildrenFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/children/AggregateChildrenFunDef.java
@@ -32,7 +32,7 @@ public class AggregateChildrenFunDef extends AbstractFunctionDefinition {
     static OperationAtom functionAtom$AggregateChildren = new InternalOperationAtom("$AggregateChildren");
     static FunctionMetaData functionMetaData$AggregateChildren = new FunctionMetaDataR(functionAtom$AggregateChildren,
             "Equivalent to 'Aggregate(<Hierarchy>.CurrentMember.Children); for internal use.",
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) });
 
     public AggregateChildrenFunDef() {
         super(functionMetaData$AggregateChildren);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/count/CountFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/count/CountFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class CountFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Count");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the number of tuples in a set including empty cells.", DataType.NUMERIC,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.SET )});
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.SET)}).interfaceName(FunctionInterface.STATISTICAL);
 
     public CountFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/median/MedianResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/aggregate/median/MedianResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,12 @@ import org.osgi.service.component.annotations.Component;
 public class MedianResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Median");
     private static String DESCRIPTION = "Returns the median value of a numeric expression evaluated over a set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Percentile") };
-    // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC, "Percentile").asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public MedianResolver() {
-        super(List.of(new MedianFunDef(functionMetaData), new MedianFunDef(functionMetaData1)));
+        super(List.of(new MedianFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/ancestor/AncestorLevelFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/ancestor/AncestorLevelFunDef.java
@@ -20,6 +20,7 @@ import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.exception.OlapRuntimeException;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
@@ -33,7 +34,7 @@ class AncestorLevelFunDef extends AbstractFunctionDefinition {
 
 	static final FunctionMetaData fmdLevel = new FunctionMetaDataR(AncestorResolver.operationAtom,
 			"Returns the ancestor of a member at a specified level.", DataType.MEMBER,
-			new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ), new FunctionParameterR( DataType.LEVEL ) });
+			new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.LEVEL) }).interfaceName(FunctionInterface.NAVIGATION);
 
 	public AncestorLevelFunDef() {
 		super(fmdLevel);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/ancestor/AncestorNumericFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/ancestor/AncestorNumericFunDef.java
@@ -20,6 +20,7 @@ import org.eclipse.daanse.olap.api.calc.IntegerCalc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.exception.OlapRuntimeException;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
@@ -33,7 +34,7 @@ class AncestorNumericFunDef extends AbstractFunctionDefinition {
 
 	static final FunctionMetaData fmdNum = new FunctionMetaDataR(AncestorResolver.operationAtom,
 			"Returns the ancestor of a member at a specified level, defined by the distance.", DataType.MEMBER,
-			new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ), new FunctionParameterR( DataType.NUMERIC) });
+			new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.NUMERIC) }).interfaceName(FunctionInterface.NAVIGATION);
 
 	public AncestorNumericFunDef() {
 		super(fmdNum);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/as/AsAliasFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/as/AsAliasFunDef.java
@@ -51,7 +51,7 @@ public class AsAliasFunDef extends AbstractFunctionDefinition {
 
 	static final OperationAtom functionAtom = new InfixOperationAtom("AS");
 	static final FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom, DESCRIPTION,
-			DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.SET ), new FunctionParameterR( DataType.NUMERIC ) });
+			DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.NUMERIC) });
 
 	private final QueryImpl.ScopedNamedSet scopedNamedSet;
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/as/AsAliasResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/as/AsAliasResolver.java
@@ -25,15 +25,22 @@
  */
 package org.eclipse.daanse.olap.function.def.as;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.query.component.NamedSetExpression;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.eclipse.daanse.olap.query.component.QueryImpl;
 import org.osgi.service.component.annotations.Component;
@@ -42,9 +49,10 @@ import org.osgi.service.component.annotations.Component;
 public class AsAliasResolver extends NoExpressionRequiredFunctionResolver {
 
 	@Override
-	public FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions) {
+	public Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator) {
+		List<Conversion> conversions = new ArrayList<>();
 		if (!validator.canConvert(0, args[0], DataType.SET, conversions)) {
-			return null;
+			return Optional.empty();
 		}
 
 		// By the time resolve is called, the id argument has already been
@@ -57,11 +65,21 @@ public class AsAliasResolver extends NoExpressionRequiredFunctionResolver {
 
 		QueryImpl.ScopedNamedSet scopedNamedSet = (QueryImpl.ScopedNamedSet) nse.getNamedSet();
 
-		return new AsAliasFunDef(scopedNamedSet);
+		return Optional.of(FunctionResolutionResultR.of(new AsAliasFunDef(scopedNamedSet), conversions));
 	}
 
 	@Override
 	public OperationAtom getFunctionAtom() {
 		return AsAliasFunDef.functionAtom;
+	}
+
+	private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+			FunctionMetaDataR.of(AsAliasFunDef.functionAtom, AsAliasFunDef.DESCRIPTION, DataType.SET,
+					param(DataType.SET, "Set_Expression"),
+					param(DataType.STRING, "Alias")));
+
+	@Override
+	public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+		return REPRESENTATIVE_METADATAS;
 	}
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/cache/CacheFunResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/cache/CacheFunResolver.java
@@ -13,13 +13,20 @@
 */
 package org.eclipse.daanse.olap.function.def.cache;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.osgi.service.component.annotations.Component;
 
@@ -27,16 +34,15 @@ import org.osgi.service.component.annotations.Component;
 public class CacheFunResolver extends NoExpressionRequiredFunctionResolver {
 
     @Override
-    public FunctionDefinition resolve(
+    public Optional<FunctionResolutionResult> resolve(
         Expression[] args,
-        Validator validator,
-        List<Conversion> conversions)
+        Validator validator)
     {
         if (args.length != 1) {
-            return null;
+            return Optional.empty();
         }
         final Expression exp = args[0];
-        return new CacheFunDef(exp.getCategory());
+        return Optional.of(FunctionResolutionResultR.of(new CacheFunDef(exp.getCategory()), List.<Conversion>of()));
     }
 
     @Override
@@ -44,5 +50,14 @@ public class CacheFunResolver extends NoExpressionRequiredFunctionResolver {
         return CacheFunDef.functionAtom;
     }
 
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+            FunctionMetaDataR.of(CacheFunDef.functionAtom,
+                    "Evaluates and returns its sole argument, applying statement-level caching", DataType.VALUE,
+                    param(DataType.VALUE)));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
+    }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/dimension/CaptionFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/dimension/CaptionFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.DimensionCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class CaptionFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Caption");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the caption of a dimension.", DataType.STRING,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.DIMENSION ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.DIMENSION) }).interfaceName(FunctionInterface.METADATA);
 
     public CaptionFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/hierarchy/CaptionFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/hierarchy/CaptionFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.HierarchyCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,7 +32,7 @@ public class CaptionFunDef extends AbstractFunctionDefinition {
     static OperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Caption");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the caption of a hierarchy.", DataType.STRING,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY )});
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY)}).interfaceName(FunctionInterface.METADATA);
 
     public CaptionFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/level/CaptionFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/level/CaptionFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.LevelCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class CaptionFunDef extends AbstractFunctionDefinition {
     // <Level>.Caption
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Caption");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom, "Returns the caption of a level.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.LEVEL ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) }).interfaceName(FunctionInterface.METADATA);
 
     public CaptionFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/member/CaptionFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/member/CaptionFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class CaptionFunDef extends AbstractFunctionDefinition {
     // <Member>.Caption
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Caption");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom, "Returns the caption of a member.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.METADATA);
 
     public CaptionFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/member/MemberCaptionFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/caption/member/MemberCaptionFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class MemberCaptionFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Member_Caption");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the caption of a member.", DataType.STRING,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.METADATA);
 
     public MemberCaptionFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/cast/CaseMatchResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/cast/CaseMatchResolver.java
@@ -13,15 +13,22 @@
 */
 package org.eclipse.daanse.olap.function.def.cast;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.common.Util;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.eclipse.daanse.olap.query.base.Expressions;
 import org.osgi.service.component.annotations.Component;
@@ -33,9 +40,10 @@ public class CaseMatchResolver extends NoExpressionRequiredFunctionResolver {
     }
 
     @Override
-    public FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions) {
+    public Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator) {
+        List<Conversion> conversions = new ArrayList<>();
         if (args.length < 3) {
-            return null;
+            return Optional.empty();
         }
         DataType valueType = args[0].getCategory();
         DataType returnType = args[2].getCategory();
@@ -60,10 +68,11 @@ public class CaseMatchResolver extends NoExpressionRequiredFunctionResolver {
 
         Util.assertTrue(j == args.length);
         if (mismatchingArgs != 0) {
-            return null;
+            return Optional.empty();
         }
 
-        return new CaseMatchFunDef(returnType, Expressions.functionParameterOf(args));
+        return Optional.of(FunctionResolutionResultR
+                .of(new CaseMatchFunDef(returnType, Expressions.functionParameterOf(args)), conversions));
     }
 
     @Override
@@ -74,5 +83,17 @@ public class CaseMatchResolver extends NoExpressionRequiredFunctionResolver {
     @Override
     public OperationAtom getFunctionAtom() {
         return CaseMatchFunDef.functionAtom;
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+            FunctionMetaDataR.of(CaseMatchFunDef.functionAtom, CaseMatchFunDef.DESCRIPTION, DataType.VALUE,
+                    param(DataType.VALUE, "Match_Expression"),
+                    param(DataType.VALUE, "Case_Value").repeatable(1),
+                    param(DataType.VALUE, "Value_Expression").repeatable(1),
+                    param(DataType.VALUE, "Else_Value").asOptional()));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/cast/CaseTestResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/cast/CaseTestResolver.java
@@ -13,24 +13,32 @@
 */
 package org.eclipse.daanse.olap.function.def.cast;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.common.Util;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.query.base.Expressions;
 import org.osgi.service.component.annotations.Component;
 
 @Component(service = FunctionResolver.class)
 public class CaseTestResolver  implements FunctionResolver {
     @Override
-    public FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions) {
+    public Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator) {
+        List<Conversion> conversions = new ArrayList<>();
         if (args.length < 1) {
-            return null;
+            return Optional.empty();
         }
         int j = 0;
         int clauseCount = args.length / 2;
@@ -50,10 +58,11 @@ public class CaseTestResolver  implements FunctionResolver {
         }
         Util.assertTrue(j == args.length);
         if (mismatchingArgs != 0) {
-            return null;
+            return Optional.empty();
         }
 
-        return new CaseTestFunDef(returnType, Expressions.functionParameterOf(args));
+        return Optional.of(FunctionResolutionResultR
+                .of(new CaseTestFunDef(returnType, Expressions.functionParameterOf(args)), conversions));
     }
 
     @Override
@@ -65,6 +74,17 @@ public class CaseTestResolver  implements FunctionResolver {
     public OperationAtom getFunctionAtom() {
 
         return CaseTestFunDef.functionAtom;
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+            FunctionMetaDataR.of(CaseTestFunDef.functionAtom, CaseTestFunDef.DESCRIPTION, DataType.VALUE,
+                    param(DataType.LOGICAL, "Condition").repeatable(1),
+                    param(DataType.VALUE, "Value_Expression").repeatable(1),
+                    param(DataType.VALUE, "Else_Value").asOptional()));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/coalesceempty/CoalesceEmptyResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/coalesceempty/CoalesceEmptyResolver.java
@@ -13,30 +13,35 @@
  */
 package org.eclipse.daanse.olap.function.def.coalesceempty;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.osgi.service.component.annotations.Component;
 
 @Component(service = FunctionResolver.class)
 public class CoalesceEmptyResolver implements FunctionResolver {
 
     @Override
-    public FunctionDefinition resolve(
+    public Optional<FunctionResolutionResult> resolve(
         Expression[] args,
-        Validator validator,
-        List<Conversion> conversions)
+        Validator validator)
     {
+        List<Conversion> conversions = new ArrayList<>();
         if (args.length < 1) {
-            return null;
+            return Optional.empty();
         }
         final DataType[] types = {DataType.NUMERIC, DataType.STRING};
         final FunctionParameterR[] argTypes = new FunctionParameterR[args.length];
@@ -54,10 +59,10 @@ public class CoalesceEmptyResolver implements FunctionResolver {
                 FunctionMetaData functionMetaData=new FunctionMetaDataR( CoalesceEmptyFunDef.functionAtom,
                     "Coalesces an empty cell value to a different value. All of the expressions must be of the same type (number or string).",
                     type, argTypes);
-                return new CoalesceEmptyFunDef(functionMetaData);
+                return Optional.of(FunctionResolutionResultR.of(new CoalesceEmptyFunDef(functionMetaData), conversions));
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     @Override
@@ -68,5 +73,21 @@ public class CoalesceEmptyResolver implements FunctionResolver {
     @Override
     public OperationAtom getFunctionAtom() {
         return CoalesceEmptyFunDef.functionAtom;
+    }
+
+    private static final String DESCRIPTION =
+        "Coalesces an empty cell value to a different value. All of the expressions must be of the same type (number or string).";
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+        FunctionMetaDataR.of(CoalesceEmptyFunDef.functionAtom, DESCRIPTION, DataType.NUMERIC,
+            param(DataType.NUMERIC),
+            param(DataType.NUMERIC).repeatable(1)),
+        FunctionMetaDataR.of(CoalesceEmptyFunDef.functionAtom, DESCRIPTION, DataType.STRING,
+            param(DataType.STRING),
+            param(DataType.STRING).repeatable(1)));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/correlation/CorrelationResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/correlation/CorrelationResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,16 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class CorrelationResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Correlation");
     private static String DESCRIPTION = "Returns the correlation of two series evaluated over a set.";
-    // {"fnxn", "fnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(DataType.SET),
-                    new FunctionParameterR(DataType.NUMERIC) });
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(DataType.SET),
-                    new FunctionParameterR(DataType.NUMERIC), new FunctionParameterR(DataType.NUMERIC) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC),
+                    FunctionParameterR.param(DataType.NUMERIC).asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public CorrelationResolver() {
-        super(List.of(new CorrelationFunDef(functionMetaData), new CorrelationFunDef(functionMetaData1)));
+        super(List.of(new CorrelationFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/count/CountResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/count/CountResolver.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,18 +31,15 @@ public class CountResolver extends AbstractFunctionDefinitionMultiResolver {
     static final List<String> ReservedWords =  List.of( "INCLUDEEMPTY", "EXCLUDEEMPTY" );
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Count");
     private static String DESCRIPTION = "Returns the number of tuples in a set, empty cells included unless the optional EXCLUDEEMPTY flag is used.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xy = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.SYMBOL, "PrePost", Optional.of(ReservedWords)) };
-    // {"fnx", "fnxy"}
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xy);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    new FunctionParameterR(DataType.SYMBOL, "Empty_Flag", Optional.of(ReservedWords))
+                            .describedAs("INCLUDEEMPTY (default) counts empty cells, EXCLUDEEMPTY skips them.")
+                            .asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public CountResolver() {
-        super(List.of(new CountFunDef(functionMetaData1), new CountFunDef(functionMetaData2)));
+        super(List.of(new CountFunDef(functionMetaData)));
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/covariance/CovarianceNResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/covariance/CovarianceNResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,18 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class CovarianceNResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("CovarianceN");
     private static String DESCRIPTION = "Returns the covariance of two series evaluated over a set (unbiased).";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC), new FunctionParameterR(DataType.NUMERIC) };
-    // {"fnxn", "fnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xnn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC),
+                    FunctionParameterR.param(DataType.NUMERIC).asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public CovarianceNResolver() {
-        super(List.of(new CovarianceFunDef(functionMetaData), new CovarianceFunDef(functionMetaData1)));
+        super(List.of(new CovarianceFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/covariance/CovarianceResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/covariance/CovarianceResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,18 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class CovarianceResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Covariance");
     private static String DESCRIPTION = "Returns the covariance of two series evaluated over a set (biased).";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Numeric Expression1"), new FunctionParameterR(DataType.NUMERIC, "Numeric Expression2") };
-    // {"fnxn", "fnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xnn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric Expression1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric Expression2").asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public CovarianceResolver() {
-        super(List.of(new CovarianceFunDef(functionMetaData), new CovarianceFunDef(functionMetaData1)));
+        super(List.of(new CovarianceFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/crossjoin/CrossJoinResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/crossjoin/CrossJoinResolver.java
@@ -13,16 +13,23 @@
  */
 package org.eclipse.daanse.olap.function.def.crossjoin;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
+import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.eclipse.daanse.olap.query.base.Expressions;
 import org.osgi.service.component.annotations.Component;
@@ -32,25 +39,25 @@ public class CrossJoinResolver  extends NoExpressionRequiredFunctionResolver {
     static OperationAtom functionAtom = new FunctionOperationAtom("Crossjoin");
 
     @Override
-    public FunctionDefinition resolve(
+    public Optional<FunctionResolutionResult> resolve(
             Expression[] args,
-            Validator validator,
-            List<Conversion> conversions)
+            Validator validator)
     {
+      List<Conversion> conversions = new ArrayList<>();
       if (args.length < 2) {
-        return null;
+        return Optional.empty();
       } else {
         for (int i = 0; i < args.length; i++) {
           if (!validator.canConvert(
                   i, args[i], org.eclipse.daanse.olap.api.DataType.SET, conversions)) {
-            return null;
+            return Optional.empty();
           }
         }
 
 
         FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom, "Returns the cross product of two sets.",
                 org.eclipse.daanse.olap.api.DataType.SET, Expressions.functionParameterOf(args));
-        return new CrossJoinFunDef(functionMetaData);
+        return Optional.of(FunctionResolutionResultR.of(new CrossJoinFunDef(functionMetaData), conversions));
       }
     }
 
@@ -61,5 +68,15 @@ public class CrossJoinResolver  extends NoExpressionRequiredFunctionResolver {
     @Override
     public OperationAtom getFunctionAtom() {
         return functionAtom;
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+        FunctionMetaDataR.of(functionAtom, "Returns the cross product of two sets.", DataType.SET,
+            param(DataType.SET, "Set1"),
+            param(DataType.SET, "Set2").repeatable(1)));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
   }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/crossjoin/StarCrossJoinResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/crossjoin/StarCrossJoinResolver.java
@@ -13,13 +13,16 @@
  */
 package org.eclipse.daanse.olap.function.def.crossjoin;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.InfixOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
@@ -33,22 +36,22 @@ public class StarCrossJoinResolver extends AbstractFunctionDefinitionMultiResolv
 
     static final OperationAtom atom = new InfixOperationAtom("*");
 
-    static final FunctionParameterR[] starCrossJoinSetSetParam = { new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.SET) };
+    static final FunctionParameterR[] starCrossJoinSetSetParam = { FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.SET) };
     static final FunctionMetaData starCrossJoinSetSet = new FunctionMetaDataR(atom,
             "Returns the cross product of two sets.", DataType.SET,
             starCrossJoinSetSetParam);
 
-    static final FunctionParameterR[] starCrossJoinSetMemberParam = { new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.MEMBER) };
+    static final FunctionParameterR[] starCrossJoinSetMemberParam = { FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.MEMBER) };
     static final FunctionMetaData starCrossJoinSetMember = new FunctionMetaDataR(atom,
             "Returns the cross product of Set and Member.", DataType.SET,
             starCrossJoinSetMemberParam);
 
-    static final FunctionParameterR[] starCrossJoinMemberSetParam = { new FunctionParameterR(DataType.MEMBER), new FunctionParameterR(DataType.SET) };
+    static final FunctionParameterR[] starCrossJoinMemberSetParam = { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.SET) };
     static final FunctionMetaData starCrossJoinMemberSet = new FunctionMetaDataR(atom,
             "Returns the cross product of Member and Set.", DataType.SET,
             starCrossJoinMemberSetParam);
 
-    static final FunctionParameterR[] starCrossJoinMemberMemberParam = { new FunctionParameterR(DataType.MEMBER), new FunctionParameterR(DataType.MEMBER) };
+    static final FunctionParameterR[] starCrossJoinMemberMemberParam = { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.MEMBER) };
     static final FunctionMetaData starCrossJoinMemberMember = new FunctionMetaDataR(atom,
             "Returns the cross product of two Members.", DataType.SET,
             starCrossJoinMemberMemberParam);
@@ -59,15 +62,25 @@ public class StarCrossJoinResolver extends AbstractFunctionDefinitionMultiResolv
     }
 
     @Override
-    public FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions) {
+    public Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator) {
         // This function only applies in contexts which require a set.
         // Elsewhere, "*" is the multiplication operator.
         // This means that [Measures].[Unit Sales] * [Gender].[M] is
         // well-defined.
         if (validator.requiresExpression()) {
-            return null;
+            return Optional.empty();
         }
-        return super.resolve(args, validator, conversions);
+        return super.resolve(args, validator);
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+            FunctionMetaDataR.of(atom, "Returns the cross product of two sets.", DataType.SET,
+                    param(DataType.SET, "Set1"),
+                    param(DataType.SET, "Set2").repeatable(1)));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/descendants/DescendantsMemberResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/descendants/DescendantsMemberResolver.java
@@ -26,20 +26,20 @@ import org.osgi.service.component.annotations.Component;
 
 @Component(service = FunctionResolver.class)
 public class DescendantsMemberResolver extends AbstractFunctionDefinitionMultiResolver {
-    private static String descFlagDescription = "SELF, AFTER, BEFORE, BEFORE_AND_AFTER, SELF_AND_AFTER, SELF_AND_BEFORE, SELF_BEFORE_AFTER, LEAVES";
+    private static String descFlagDescription = "Controls which levels relative to the member are included: SELF, AFTER, BEFORE, BEFORE_AND_AFTER, SELF_AND_AFTER, SELF_AND_BEFORE, SELF_BEFORE_AFTER, LEAVES.";
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Descendants");
     private static String DESCRIPTION = "Returns the set of descendants of a member at a specified level, optionally including or excluding descendants in other levels.";
-    private static FunctionParameterR[] m = { new FunctionParameterR(DataType.MEMBER) };
-    private static FunctionParameterR[] ml = { new FunctionParameterR(DataType.MEMBER),
-            new FunctionParameterR(DataType.LEVEL) };
-    private static FunctionParameterR[] mly = { new FunctionParameterR(DataType.MEMBER),
-            new FunctionParameterR(DataType.LEVEL), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
-    private static FunctionParameterR[] mn = { new FunctionParameterR(DataType.MEMBER),
-            new FunctionParameterR(DataType.NUMERIC) };
-    private static FunctionParameterR[] mny = { new FunctionParameterR(DataType.MEMBER),
-            new FunctionParameterR(DataType.NUMERIC), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
-    private static FunctionParameterR[] mey = { new FunctionParameterR(DataType.MEMBER),
-            new FunctionParameterR(DataType.EMPTY), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
+    private static FunctionParameterR[] m = { FunctionParameterR.param(DataType.MEMBER) };
+    private static FunctionParameterR[] ml = { FunctionParameterR.param(DataType.MEMBER),
+            FunctionParameterR.param(DataType.LEVEL) };
+    private static FunctionParameterR[] mly = { FunctionParameterR.param(DataType.MEMBER),
+            FunctionParameterR.param(DataType.LEVEL), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
+    private static FunctionParameterR[] mn = { FunctionParameterR.param(DataType.MEMBER),
+            FunctionParameterR.param(DataType.NUMERIC) };
+    private static FunctionParameterR[] mny = { FunctionParameterR.param(DataType.MEMBER),
+            FunctionParameterR.param(DataType.NUMERIC), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
+    private static FunctionParameterR[] mey = { FunctionParameterR.param(DataType.MEMBER),
+            FunctionParameterR.param(DataType.EMPTY), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
     // {"fxm", "fxml", "fxmly", "fxmn", "fxmny", "fxmey"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION, DataType.SET,

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/descendants/DescendantsSetResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/descendants/DescendantsSetResolver.java
@@ -27,21 +27,21 @@ import org.osgi.service.component.annotations.Component;
 
 @Component(service = FunctionResolver.class)
 public class DescendantsSetResolver extends AbstractFunctionDefinitionMultiResolver {
-    private static String descFlagDescription = "SELF, AFTER, BEFORE, BEFORE_AND_AFTER, SELF_AND_AFTER, SELF_AND_BEFORE, SELF_BEFORE_AFTER, LEAVES";
+    private static String descFlagDescription = "Controls which levels relative to the member are included: SELF, AFTER, BEFORE, BEFORE_AND_AFTER, SELF_AND_AFTER, SELF_AND_BEFORE, SELF_BEFORE_AFTER, LEAVES.";
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Descendants");
     private static String DESCRIPTION = "Returns the set of descendants of a set of members at a specified level, optionally including or excluding descendants in other levels.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xl = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.LEVEL) };
-    private static FunctionParameterR[] xly = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.LEVEL), new FunctionParameterR(DataType.SYMBOL, Optional.of("Desc_flag"),
+    private static FunctionParameterR[] x = { FunctionParameterR.param(DataType.SET) };
+    private static FunctionParameterR[] xl = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.LEVEL) };
+    private static FunctionParameterR[] xly = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.LEVEL), new FunctionParameterR(DataType.SYMBOL, Optional.of("Desc_flag"),
                     Optional.of(descFlagDescription), Optional.of(Flag.asReservedWords())) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
-    private static FunctionParameterR[] xny = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
-    private static FunctionParameterR[] xey = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.EMPTY), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC) };
+    private static FunctionParameterR[] xny = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
+    private static FunctionParameterR[] xey = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.EMPTY), new FunctionParameterR(DataType.SYMBOL, "Desc_flag", descFlagDescription) };
     // {"fxx", "fxxl", "fxxly", "fxxn", "fxxny", "fxxey"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION, DataType.SET,

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/current/CurrentFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/current/CurrentFunDef.java
@@ -27,7 +27,7 @@ public class CurrentFunDef extends AbstractFunctionDefinition {
 
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Current");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom, "Returns the current tuple from a set during an iteration.",
-            DataType.TUPLE, new FunctionParameterR[] { new FunctionParameterR(  DataType.SET ) });
+            DataType.TUPLE, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) });
 
 	public CurrentFunDef() {
 		super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/dimension/DimensionOfDimensionFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/dimension/DimensionOfDimensionFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.element.Dimension;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.DimensionExpression;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
@@ -33,7 +34,7 @@ public class DimensionOfDimensionFunDef extends AbstractFunctionDefinition {
 
 	private static final FunctionMetaData functionMetaData = new FunctionMetaDataR(atom,
 			"Returns the dimension that contains a specified dimension.", DataType.DIMENSION,
-			new FunctionParameterR[] { new FunctionParameterR( DataType.DIMENSION ) });
+			new FunctionParameterR[] { FunctionParameterR.param(DataType.DIMENSION) }).interfaceName(FunctionInterface.METADATA);
 
 	public DimensionOfDimensionFunDef() {
 		super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/hierarchy/DimensionOfHierarchyFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/hierarchy/DimensionOfHierarchyFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.HierarchyCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.calc.base.type.dimension.DimensionOfHierarchyCalc;
@@ -32,7 +33,7 @@ public class DimensionOfHierarchyFunDef extends AbstractFunctionDefinition {
 
 	private static final FunctionMetaData functionMetaData = new FunctionMetaDataR(atom,
 			"Returns the dimension that contains a specified hierarchy.", DataType.DIMENSION,
-			new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY ) });
+			new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) }).interfaceName(FunctionInterface.METADATA);
 
 	public DimensionOfHierarchyFunDef() {
 		super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/level/DimensionOfLevelFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/level/DimensionOfLevelFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.LevelCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,7 +32,7 @@ public class DimensionOfLevelFunDef extends AbstractFunctionDefinition {
 
 	private static final FunctionMetaData functionMetaData = new FunctionMetaDataR(atom,
 			"Returns the dimension that contains a specified level.", DataType.DIMENSION,
-			new FunctionParameterR[] { new FunctionParameterR(  DataType.LEVEL) });
+			new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) }).interfaceName(FunctionInterface.METADATA);
 
 	public DimensionOfLevelFunDef() {
 		super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/member/DimensionOfMemberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/dimension/member/DimensionOfMemberFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,7 +32,7 @@ public class DimensionOfMemberFunDef extends AbstractFunctionDefinition {
 
 	private static final FunctionMetaData functionMetaData = new FunctionMetaDataR(atom,
 			"Returns the dimension that contains a specified member.", DataType.DIMENSION,
-			new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER )});
+			new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER)}).interfaceName(FunctionInterface.METADATA);
 
 	public DimensionOfMemberFunDef() {
 		super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/dimensions/numeric/DimensionsNumericFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/dimensions/numeric/DimensionsNumericFunDef.java
@@ -52,7 +52,7 @@ public class DimensionsNumericFunDef extends AbstractFunctionDefinition {
 	static final String DIMENSIONS_NUMERIC_FUN_DESCRIPTION = "Returns the hierarchy whose zero-based position within the cube is specified by a numeric expression.";
 	static final OperationAtom atom = new FunctionOperationAtom("Dimensions");
 	static final FunctionMetaData functionalMetaData = new FunctionMetaDataR(atom, DIMENSIONS_NUMERIC_FUN_DESCRIPTION,
-			DataType.HIERARCHY, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC, "Numeric Expression" ) });
+			DataType.HIERARCHY, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric Expression") });
 
 	public DimensionsNumericFunDef() {
 		super(functionalMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/dimensions/string/DimensionsStringFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/dimensions/string/DimensionsStringFunDef.java
@@ -35,7 +35,7 @@ class DimensionsStringFunDef extends AbstractFunctionDefinition {
 
     static final FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Returns the hierarchy whose name is specified by a string.", DataType.HIERARCHY,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String") });
 
     public DimensionsStringFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/drilldownlevel/DrilldownLevelResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/drilldownlevel/DrilldownLevelResolver.java
@@ -30,15 +30,17 @@ public class DrilldownLevelResolver extends AbstractFunctionDefinitionMultiResol
     private static FunctionOperationAtom atom = new FunctionOperationAtom("DrilldownLevel");
     private static List<String> RESERVED_WORDS = List.of("INCLUDE_CALC_MEMBERS");
     private static String DESCRIPTION = "Drills down the members of a set, at a specified level, to one level below. Alternatively, drills down on a specified dimension in the set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xl = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.LEVEL) };
-    private static FunctionParameterR[] xen = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.EMPTY), new FunctionParameterR(DataType.NUMERIC, "Index") };
-    private static FunctionParameterR[] xeny = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.EMPTY), new FunctionParameterR(DataType.NUMERIC, "Index"), new FunctionParameterR(DataType.SYMBOL, "Include members", Optional.of(RESERVED_WORDS))};
-    private static FunctionParameterR[] xeey = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.EMPTY), new FunctionParameterR(DataType.EMPTY), new FunctionParameterR(DataType.SYMBOL, "Include members", Optional.of(RESERVED_WORDS)) };
+    private static FunctionParameterR[] x = { FunctionParameterR.param(DataType.SET) };
+    private static FunctionParameterR[] xl = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.LEVEL) };
+    private static FunctionParameterR[] xen = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.EMPTY), FunctionParameterR.param(DataType.NUMERIC, "Index") };
+    private static FunctionParameterR[] xeny = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.EMPTY), FunctionParameterR.param(DataType.NUMERIC, "Index"), new FunctionParameterR(DataType.SYMBOL, "Include members", Optional.of(RESERVED_WORDS))
+                    .describedAs("INCLUDE_CALC_MEMBERS includes calculated members in the drilled-down result.")};
+    private static FunctionParameterR[] xeey = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.EMPTY), FunctionParameterR.param(DataType.EMPTY), new FunctionParameterR(DataType.SYMBOL, "Include members", Optional.of(RESERVED_WORDS))
+                    .describedAs("INCLUDE_CALC_MEMBERS includes calculated members in the drilled-down result.") };
     // {"fxx", "fxxl", "fxxen", "fxxeny", "fxxeey"}
 
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/drilldownleveltopbottom/DrilldownLevelBottomResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/drilldownleveltopbottom/DrilldownLevelBottomResolver.java
@@ -28,16 +28,16 @@ import org.osgi.service.component.annotations.Component;
 public class DrilldownLevelBottomResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("DrilldownLevelBottom");
     private static String DESCRIPTION = "Drills down the bottommost members of a set, at a specified level, to one level below.";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count") };
-    private static FunctionParameterR[] xnl = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count"), new FunctionParameterR(DataType.LEVEL) };
-    private static FunctionParameterR[] xnln = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count"), new FunctionParameterR(DataType.LEVEL),
-            new FunctionParameterR(DataType.NUMERIC, "Numeric_Expression") };
-    private static FunctionParameterR[] xnen = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count"), new FunctionParameterR(DataType.EMPTY),
-            new FunctionParameterR(DataType.NUMERIC, "Numeric_Expression") };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count") };
+    private static FunctionParameterR[] xnl = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count"), FunctionParameterR.param(DataType.LEVEL) };
+    private static FunctionParameterR[] xnln = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count"), FunctionParameterR.param(DataType.LEVEL),
+            FunctionParameterR.param(DataType.NUMERIC, "Numeric_Expression") };
+    private static FunctionParameterR[] xnen = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count"), FunctionParameterR.param(DataType.EMPTY),
+            FunctionParameterR.param(DataType.NUMERIC, "Numeric_Expression") };
     // {"fxxn", "fxxnl", "fxxnln", "fxxnen"}
 
     private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/drilldownleveltopbottom/DrilldownLevelTopResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/drilldownleveltopbottom/DrilldownLevelTopResolver.java
@@ -28,16 +28,16 @@ import org.osgi.service.component.annotations.Component;
 public class DrilldownLevelTopResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("DrilldownLevelTop");
     private static String DESCRIPTION = "Drills down the topmost members of a set, at a specified level, to one level below.";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count") };
-    private static FunctionParameterR[] xnl = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count"), new FunctionParameterR(DataType.LEVEL) };
-    private static FunctionParameterR[] xnln = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count"), new FunctionParameterR(DataType.LEVEL),
-            new FunctionParameterR(DataType.NUMERIC, "Numeric Expression") };
-    private static FunctionParameterR[] xnen = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count"), new FunctionParameterR(DataType.EMPTY),
-            new FunctionParameterR(DataType.NUMERIC, "Numeric Expression") };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count") };
+    private static FunctionParameterR[] xnl = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count"), FunctionParameterR.param(DataType.LEVEL) };
+    private static FunctionParameterR[] xnln = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count"), FunctionParameterR.param(DataType.LEVEL),
+            FunctionParameterR.param(DataType.NUMERIC, "Numeric Expression") };
+    private static FunctionParameterR[] xnen = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count"), FunctionParameterR.param(DataType.EMPTY),
+            FunctionParameterR.param(DataType.NUMERIC, "Numeric Expression") };
     // {"fxxn", "fxxnl", "fxxnln", "fxxnen"}
 
     private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/drilldownmember/DrilldownMemberResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/drilldownmember/DrilldownMemberResolver.java
@@ -30,24 +30,21 @@ public class DrilldownMemberResolver extends AbstractFunctionDefinitionMultiReso
     private static FunctionOperationAtom atom = new FunctionOperationAtom("DrilldownMember");
     private static List<String> reservedWords = List.of("RECURSIVE");
     private static String DESCRIPTION = "Drills down the members in a set that are present in a second specified set.";
-    private static FunctionParameterR[] xx = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2") };
-    private static FunctionParameterR[] xxy = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2"), new FunctionParameterR(DataType.SYMBOL, "Recursive", Optional.of(reservedWords)) };
-    // {"fxxx", "fxxxy"}
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xx);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xxy);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET, "Set1"),
+                    FunctionParameterR.param(DataType.SET, "Set2"),
+                    new FunctionParameterR(DataType.SYMBOL, "Recursive", Optional.of(reservedWords))
+                            .describedAs("RECURSIVE drills down every matching member at every level, not only the first match.")
+                            .asOptional() });
 
     @Override
     public List<String> getReservedWords() {
         return reservedWords;
     }
 
-    
+
     public DrilldownMemberResolver() {
-        super(List.of(new DrilldownMemberFunDef(functionMetaData1), new DrilldownMemberFunDef(functionMetaData2)));
+        super(List.of(new DrilldownMemberFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/acos/AcosFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/acos/AcosFunDef.java
@@ -32,7 +32,7 @@ public class AcosFunDef  extends AbstractFunctionDefinition {
         is the angle whose cosine is Arg1. The returned angle is given in
         radians in the range 0 (zero) to pi.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public AcosFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/acos/AcoshFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/acos/AcoshFunDef.java
@@ -33,7 +33,7 @@ public class AcoshFunDef  extends AbstractFunctionDefinition {
         value whose hyperbolic cosine is Arg1, so Acosh(Cosh(number))
         equals Arg1.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public AcoshFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinFunDef.java
@@ -32,7 +32,7 @@ public class AsinFunDef  extends AbstractFunctionDefinition {
         angle whose sine is Arg1. The returned angle is given in radians in
         the range -pi/2 to pi/2.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public AsinFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinhFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/asin/AsinhFunDef.java
@@ -32,7 +32,7 @@ public class AsinhFunDef  extends AbstractFunctionDefinition {
         hyperbolic sine is the value whose hyperbolic sine is Arg1,
         so Asinh(Sinh(number)) equals Arg1.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public AsinhFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/atan2/Atan2FunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/atan2/Atan2FunDef.java
@@ -34,7 +34,7 @@ public class Atan2FunDef  extends AbstractFunctionDefinition {
         (x_num, y_num). The angle is given in radians between -pi and pi,
         excluding -pi.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "x" ), new FunctionParameterR( DataType.NUMERIC, "y" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "x"), FunctionParameterR.param(DataType.NUMERIC, "y") });
 
     public Atan2FunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/atan2/AtanhFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/atan2/AtanhFunDef.java
@@ -31,7 +31,7 @@ public class AtanhFunDef  extends AbstractFunctionDefinition {
         Returns the inverse hyperbolic tangent of a number. Number
         must be between -1 and 1 (excluding -1 and 1).""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public AtanhFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/cosh/CoshFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/cosh/CoshFunDef.java
@@ -30,7 +30,7 @@ public class CoshFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the hyperbolic cosine of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public CoshFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/degrees/DegreesFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/degrees/DegreesFunDef.java
@@ -30,7 +30,7 @@ public class DegreesFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Converts radians to degrees.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Radians" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Radians") });
 
     public DegreesFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/log10/Log10FunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/log10/Log10FunDef.java
@@ -30,7 +30,7 @@ public class Log10FunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the base-10 logarithm of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public Log10FunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/mod/ModFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/mod/ModFunDef.java
@@ -29,7 +29,7 @@ public class ModFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the remainder of dividing n by d.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "n" ), new FunctionParameterR( DataType.VALUE, "d" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "n"), FunctionParameterR.param(DataType.VALUE, "d") });
 
     public ModFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/power/PowerFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/power/PowerFunDef.java
@@ -30,7 +30,7 @@ public class PowerFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the result of a number raised to a power.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "x" ), new FunctionParameterR( DataType.NUMERIC, "y" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "x"), FunctionParameterR.param(DataType.NUMERIC, "y") });
 
     public PowerFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/radians/RadiansFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/radians/RadiansFunDef.java
@@ -30,7 +30,7 @@ public class RadiansFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Converts degrees to radians.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Radians" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Radians") });
 
     public RadiansFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/sinh/SinhFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/sinh/SinhFunDef.java
@@ -30,7 +30,7 @@ public class SinhFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the hyperbolic sine of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public SinhFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/sqrtpi/SqrtPiFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/sqrtpi/SqrtPiFunDef.java
@@ -30,7 +30,7 @@ public class SqrtPiFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the square root of (number * pi).""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Number" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Number") });
 
     public SqrtPiFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/tanh/TanhFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/excel/tanh/TanhFunDef.java
@@ -30,7 +30,7 @@ public class TanhFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the hyperbolic tangent of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Radians" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Radians") });
 
     public TanhFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/except/ExceptResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/except/ExceptResolver.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,19 +32,16 @@ public class ExceptResolver extends AbstractFunctionDefinitionMultiResolver {
     
     private static List<String> reservedWords = List.of("ALL");
     private static String DESCRIPTION = "Finds the difference between two sets, optionally retaining duplicates.";
-    private static FunctionParameterR[] xx = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2") };
-    private static FunctionParameterR[] xxy = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2"), new FunctionParameterR(DataType.SYMBOL, "All", Optional.of(reservedWords) ) };
-    // {"fxxx", "fxxxy"}
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xx);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xxy);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET, "Set1"),
+                    FunctionParameterR.param(DataType.SET, "Set2"),
+                    new FunctionParameterR(DataType.SYMBOL, "All", Optional.of(reservedWords))
+                            .describedAs("ALL retains duplicates while removing matching members.")
+                            .asOptional() }).interfaceName(FunctionInterface.FILTER);
 
     public ExceptResolver() {
-        super(List.of(new ExceptFunDef(functionMetaData1), new ExceptFunDef(functionMetaData2)));
+        super(List.of(new ExceptFunDef(functionMetaData)));
     }
     
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/exists/ExistsResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/exists/ExistsResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,12 +29,12 @@ import org.osgi.service.component.annotations.Component;
 public class ExistsResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Exists");
     private static String DESCRIPTION = "Returns the the set of tuples of the first set that exist with one or more tuples of the second set.";
-    private static FunctionParameterR[] xx = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2") };
+    private static FunctionParameterR[] xx = { FunctionParameterR.param(DataType.SET, "Set1"),
+            FunctionParameterR.param(DataType.SET, "Set2") };
     // {"fxxx"}
 
     private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xx);
+            DataType.SET, xx).interfaceName(FunctionInterface.FILTER);
 
     public ExistsResolver() {
         super(List.of(new ExistsFunDef(functionMetaData1)));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/format/FormatResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/format/FormatResolver.java
@@ -28,9 +28,9 @@ import org.osgi.service.component.annotations.Component;
 public class FormatResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Format");
     private static String DESCRIPTION = "Formats a number or date to a string.";
-    private static FunctionParameterR[] mS = { new FunctionParameterR(DataType.MEMBER, "Value"), new FunctionParameterR(DataType.STRING, "Format") };
-    private static FunctionParameterR[] nS = { new FunctionParameterR(DataType.NUMERIC, "Value"), new FunctionParameterR(DataType.STRING, "Format") };
-    private static FunctionParameterR[] DS = { new FunctionParameterR(DataType.DATE_TIME, "Value"), new FunctionParameterR(DataType.STRING, "Format") };
+    private static FunctionParameterR[] mS = { FunctionParameterR.param(DataType.MEMBER, "Value"), FunctionParameterR.param(DataType.STRING, "Format") };
+    private static FunctionParameterR[] nS = { FunctionParameterR.param(DataType.NUMERIC, "Value"), FunctionParameterR.param(DataType.STRING, "Format") };
+    private static FunctionParameterR[] DS = { FunctionParameterR.param(DataType.DATE_TIME, "Value"), FunctionParameterR.param(DataType.STRING, "Format") };
     // {"fSmS", "fSnS", "fSDS"}
 
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/generate/GenerateListResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/generate/GenerateListResolver.java
@@ -29,19 +29,15 @@ import org.osgi.service.component.annotations.Component;
 public class GenerateListResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Generate");
     private static String DESCRIPTION = "Applies a set to each member of another set and joins the resulting sets by union.";
-    private static FunctionParameterR[] xx = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2") };
-    private static FunctionParameterR[] xxy = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2"), new FunctionParameterR(DataType.SYMBOL, "All", Optional.of(GenerateFunDef.ReservedWords)) };
-    // {"fxxx", "fxxxy"}
 
-    
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xx);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xxy);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET, "Set1"),
+                    FunctionParameterR.param(DataType.SET, "Set2"),
+                    new FunctionParameterR(DataType.SYMBOL, "All", Optional.of(GenerateFunDef.ReservedWords))
+                            .describedAs("ALL retains duplicates produced by the iteration; without it duplicates are removed.")
+                            .asOptional() });
 
     public GenerateListResolver() {
-        super(List.of(new GenerateFunDef(functionMetaData1), new GenerateFunDef(functionMetaData2)));
+        super(List.of(new GenerateFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/generate/GenerateStringResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/generate/GenerateStringResolver.java
@@ -28,12 +28,12 @@ import org.osgi.service.component.annotations.Component;
 public class GenerateStringResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Generate");
     private static String DESCRIPTION = "Applies a set to a string expression and joins resulting sets by string concatenation.";
-    private static FunctionParameterR[] xS = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.STRING) };
-    private static FunctionParameterR[] xSS = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.STRING), new FunctionParameterR(DataType.STRING, "Separator") };
-    private static FunctionParameterR[] xnS = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC), new FunctionParameterR(DataType.STRING, "Separator") };
+    private static FunctionParameterR[] xS = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.STRING) };
+    private static FunctionParameterR[] xSS = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.STRING), FunctionParameterR.param(DataType.STRING, "Separator") };
+    private static FunctionParameterR[] xnS = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC), FunctionParameterR.param(DataType.STRING, "Separator") };
     // {"fSxS", "fSxSS", "fSxnS"}
 
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/headtail/HeadResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/headtail/HeadResolver.java
@@ -28,17 +28,13 @@ import org.osgi.service.component.annotations.Component;
 public class HeadResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Head");
     private static String DESCRIPTION = "Returns the first specified number of elements in a set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Numeric Expression") };
-    // {"fxx", "fxxn"}
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, x);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xn);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric Expression")
+                            .describedAs("Number of members to return; defaults to 1.").asOptional() });
 
     public HeadResolver() {
-        super(List.of(new HeadTailFunDef(functionMetaData1), new HeadTailFunDef(functionMetaData2)));
+        super(List.of(new HeadTailFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/headtail/TailResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/headtail/TailResolver.java
@@ -28,17 +28,13 @@ import org.osgi.service.component.annotations.Component;
 public class TailResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Tail");
     private static String DESCRIPTION = "Returns a subset from the end of a set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count") };
-    // {"fxx", "fxxn"}
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, x);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xn);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC, "Count")
+                            .describedAs("Number of members to return; defaults to 1.").asOptional() });
 
     public TailResolver() {
-        super(List.of(new HeadTailFunDef(functionMetaData1), new HeadTailFunDef(functionMetaData2)));
+        super(List.of(new HeadTailFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchize/HierarchizeResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchize/HierarchizeResolver.java
@@ -30,18 +30,15 @@ public class HierarchizeResolver extends AbstractFunctionDefinitionMultiResolver
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Hierarchize");
     private static List<String> reservedWords = List.of( "PRE", "POST" );
     private static String DESCRIPTION = "Orders the members of a set in a hierarchy.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xy = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.SYMBOL, "PrePost", Optional.of(reservedWords)) };
-    // {"fxx", "fxxy"}
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, x);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xy);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    new FunctionParameterR(DataType.SYMBOL, "PrePost", Optional.of(reservedWords))
+                            .describedAs("PRE (default) orders parents before children, POST orders children first.")
+                            .asOptional() });
 
     public HierarchizeResolver() {
-        super(List.of(new HierarchizeFunDef(functionMetaData1), new HierarchizeFunDef(functionMetaData2)));
+        super(List.of(new HierarchizeFunDef(functionMetaData)));
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchy/level/LevelHierarchyFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchy/level/LevelHierarchyFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.mdx.model.api.expression.operation.PlainPropertyOperat
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class LevelHierarchyFunDef extends AbstractFunctionDefinition {
     static OperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Hierarchy");
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
-            "Returns a level's hierarchy.", DataType.HIERARCHY, new FunctionParameterR[] { new FunctionParameterR(  DataType.LEVEL ) });
+            "Returns a level's hierarchy.", DataType.HIERARCHY, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) }).interfaceName(FunctionInterface.METADATA);
 
     public LevelHierarchyFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchy/member/HierarchyCurrentMemberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchy/member/HierarchyCurrentMemberFunDef.java
@@ -20,6 +20,7 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.HierarchyCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.element.Hierarchy;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -32,7 +33,7 @@ public class HierarchyCurrentMemberFunDef extends AbstractFunctionDefinition {
 
     static final FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the current member along a hierarchy during an iteration.",
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY ) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) }).interfaceName(FunctionInterface.NAVIGATION);
 
     static final HierarchyCurrentMemberFunDef instance = new HierarchyCurrentMemberFunDef();
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchy/member/MemberHierarchyFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchy/member/MemberHierarchyFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,7 +32,7 @@ public class MemberHierarchyFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns a member's hierarchy.", DataType.HIERARCHY,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ,"Member" ) });
+            new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ,"Member" ) }).interfaceName(FunctionInterface.METADATA);
 
     public MemberHierarchyFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchy/member/NamedSetCurrentFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/hierarchy/member/NamedSetCurrentFunDef.java
@@ -34,7 +34,7 @@ public class NamedSetCurrentFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the current member or tuple of a named set.", DataType.TUPLE,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.SET ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) });
 
     public NamedSetCurrentFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifBooleanFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifBooleanFunDef.java
@@ -28,8 +28,8 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class IifBooleanFunDef extends AbstractFunctionDefinition {
 
     static final OperationAtom BOOLEAN_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("IIf");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.LOGICAL, "Condition"),
-            new FunctionParameterR(DataType.LOGICAL, "Boolean1"), new FunctionParameterR(DataType.LOGICAL, "Boolean2") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.LOGICAL, "Condition"),
+            FunctionParameterR.param(DataType.LOGICAL, "Boolean1"), FunctionParameterR.param(DataType.LOGICAL, "Boolean2") };
     static final FunctionMetaData BOOLEAN_INSTANCE_FUNCTION_META_DATA = new FunctionMetaDataR(BOOLEAN_INSTANCE_FUNCTION_ATOM, "Returns boolean determined by a logical test.",
             DataType.LOGICAL, params);
     // IIf(<Logical Expression>, <Boolean Expression>, <Boolean Expression>)

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifDimensionResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifDimensionResolver.java
@@ -30,8 +30,8 @@ public class IifDimensionResolver extends ParametersCheckingFunctionDefinitionRe
     static final OperationAtom atom = new FunctionOperationAtom("IIf");
     private static String DESCRIPTION = "Returns one of two dimension values determined by a logical test.";
     private static FunctionParameterR[] params = new FunctionParameterR[] {
-            new FunctionParameterR(DataType.LOGICAL, "Condition"), new FunctionParameterR(DataType.DIMENSION, "Dimension1"),
-            new FunctionParameterR(DataType.DIMENSION, "Dimension2") };
+            FunctionParameterR.param(DataType.LOGICAL, "Condition"), FunctionParameterR.param(DataType.DIMENSION, "Dimension1"),
+            FunctionParameterR.param(DataType.DIMENSION, "Dimension2") };
     static FunctionMetaData metadata = new FunctionMetaDataR(atom, DESCRIPTION, DataType.DIMENSION, params);
     
     public IifDimensionResolver() {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifHierarchyResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifHierarchyResolver.java
@@ -30,8 +30,8 @@ public class IifHierarchyResolver extends ParametersCheckingFunctionDefinitionRe
     static final OperationAtom atom = new FunctionOperationAtom("IIf");
     private static String DESCRIPTION = "Returns one of two hierarchy values determined by a logical test.";
     private static FunctionParameterR[] params = new FunctionParameterR[] {
-            new FunctionParameterR(DataType.LOGICAL, "Condition"), new FunctionParameterR(DataType.HIERARCHY, "Hierarchy1"),
-            new FunctionParameterR(DataType.HIERARCHY, "Hierarchy2") };
+            FunctionParameterR.param(DataType.LOGICAL, "Condition"), FunctionParameterR.param(DataType.HIERARCHY, "Hierarchy1"),
+            FunctionParameterR.param(DataType.HIERARCHY, "Hierarchy2") };
     static FunctionMetaData metadata = new FunctionMetaDataR(atom, DESCRIPTION, DataType.HIERARCHY, params);
     
     public IifHierarchyResolver() {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifLevelResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifLevelResolver.java
@@ -30,8 +30,8 @@ public class IifLevelResolver extends ParametersCheckingFunctionDefinitionResolv
     static final OperationAtom atom = new FunctionOperationAtom("IIf");
     private static String DESCRIPTION = "Returns one of two level values determined by a logical test.";
     private static FunctionParameterR[] params = new FunctionParameterR[] {
-            new FunctionParameterR(DataType.LOGICAL, "Condition"), new FunctionParameterR(DataType.LEVEL, "Level1"),
-            new FunctionParameterR(DataType.LEVEL, "Level2") };
+            FunctionParameterR.param(DataType.LOGICAL, "Condition"), FunctionParameterR.param(DataType.LEVEL, "Level1"),
+            FunctionParameterR.param(DataType.LEVEL, "Level2") };
     static FunctionMetaData metadata = new FunctionMetaDataR(atom, DESCRIPTION, DataType.MEMBER, params);
 
     public IifLevelResolver() {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifMemberResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifMemberResolver.java
@@ -31,8 +31,8 @@ public class IifMemberResolver extends ParametersCheckingFunctionDefinitionResol
     private static String DESCRIPTION = "Returns one of two member values determined by a logical test.";
 
     private static FunctionParameterR[] params = new FunctionParameterR[] {
-            new FunctionParameterR(DataType.LOGICAL, "Condition"), new FunctionParameterR(DataType.MEMBER, "Member1"),
-            new FunctionParameterR(DataType.MEMBER, "Member2") };
+            FunctionParameterR.param(DataType.LOGICAL, "Condition"), FunctionParameterR.param(DataType.MEMBER, "Member1"),
+            FunctionParameterR.param(DataType.MEMBER, "Member2") };
     static FunctionMetaData metadata = new FunctionMetaDataR(atom, DESCRIPTION, DataType.MEMBER, params);
 
     public IifMemberResolver() {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifNumericFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifNumericFunDef.java
@@ -26,9 +26,9 @@ import org.eclipse.daanse.olap.function.core.FunctionParameterR;
 
 public class IifNumericFunDef extends IifFunDef {
 
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.LOGICAL, "Condition"),
-            new FunctionParameterR(DataType.NUMERIC, "Numeric1"),
-            new FunctionParameterR(DataType.NUMERIC, "Numeric2") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.LOGICAL, "Condition"),
+            FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+            FunctionParameterR.param(DataType.NUMERIC, "Numeric2") };
     static OperationAtom NUMERIC_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("IIf");
     static FunctionMetaData NUMERIC_INSTANCE_FUNCTION_META_DATA = new FunctionMetaDataR(NUMERIC_INSTANCE_FUNCTION_ATOM,
             "Returns one of two numeric values determined by a logical test.",

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifSetResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifSetResolver.java
@@ -30,8 +30,8 @@ public class IifSetResolver extends ParametersCheckingFunctionDefinitionResolver
     static final OperationAtom atom = new FunctionOperationAtom("IIf");
     private static String DESCRIPTION = "Returns one of two dimension values determined by a logical test.";
     private static FunctionParameterR[] params = new FunctionParameterR[] {
-            new FunctionParameterR(DataType.LOGICAL, "Condition"), new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2") };
+            FunctionParameterR.param(DataType.LOGICAL, "Condition"), FunctionParameterR.param(DataType.SET, "Set1"),
+            FunctionParameterR.param(DataType.SET, "Set2") };
     static FunctionMetaData metadata = new FunctionMetaDataR(atom, DESCRIPTION, DataType.SET, params);
 
     public IifSetResolver() {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifStringFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifStringFunDef.java
@@ -29,8 +29,8 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class IifStringFunDef extends AbstractFunctionDefinition {
 
     static OperationAtom STRING_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("IIf");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.LOGICAL, "Condition"),
-            new FunctionParameterR(DataType.STRING, "String1"), new FunctionParameterR(DataType.STRING, "String2") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.LOGICAL, "Condition"),
+            FunctionParameterR.param(DataType.STRING, "String1"), FunctionParameterR.param(DataType.STRING, "String2") };
     static FunctionMetaData STRING_INSTANCE_FUNCTION_META_DATA = new FunctionMetaDataR(STRING_INSTANCE_FUNCTION_ATOM,
             "Returns one of two string values determined by a logical test.",
             DataType.STRING, params);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifTupleFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/iif/IifTupleFunDef.java
@@ -27,8 +27,8 @@ import org.eclipse.daanse.olap.function.core.FunctionParameterR;
 public class IifTupleFunDef extends IifFunDef {
 
     static OperationAtom TUPLE_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("IIf");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.LOGICAL, "Condition"),
-            new FunctionParameterR(DataType.TUPLE, "Tuple1"), new FunctionParameterR(DataType.TUPLE, "Tuple2") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.LOGICAL, "Condition"),
+            FunctionParameterR.param(DataType.TUPLE, "Tuple1"), FunctionParameterR.param(DataType.TUPLE, "Tuple2") };
     static FunctionMetaData TUPLE_INSTANCE_FUNCTION_META_DATA = new FunctionMetaDataR(TUPLE_INSTANCE_FUNCTION_ATOM,
             "Returns one of two tuples determined by a logical test.",
             DataType.TUPLE, params);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPICurrentTimeMemberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPICurrentTimeMemberFunDef.java
@@ -28,7 +28,7 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class KPICurrentTimeMemberFunDef extends AbstractFunctionDefinition {
 
     static final OperationAtom KPI_CURRENT_TIME_MEMBER_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("KPICurrentTimeMember");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.STRING, "Kpi") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "Kpi") };
     static final FunctionMetaData FUNCTION_META_DATA = new FunctionMetaDataR(KPI_CURRENT_TIME_MEMBER_INSTANCE_FUNCTION_ATOM, "Returns KPI current time member.",
     		DataType.MEMBER, params);
     // KPITrend(<String>)

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPIGoalFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPIGoalFunDef.java
@@ -28,7 +28,7 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class KPIGoalFunDef extends AbstractFunctionDefinition {
 
     static final OperationAtom KPI_GOAL_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("KPIGoal");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.STRING, "Kpi") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "Kpi") };
     static final FunctionMetaData FUNCTION_META_DATA = new FunctionMetaDataR(KPI_GOAL_INSTANCE_FUNCTION_ATOM, "Returns KPI Goal.",
     		DataType.MEMBER, params);
     // KPIGoal(<String>)

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPIStatusFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPIStatusFunDef.java
@@ -28,7 +28,7 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class KPIStatusFunDef extends AbstractFunctionDefinition {
 
     static final OperationAtom KPI_STATUS_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("KPIStatus");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.STRING, "Kpi") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "Kpi") };
     static final FunctionMetaData FUNCTION_META_DATA = new FunctionMetaDataR(KPI_STATUS_INSTANCE_FUNCTION_ATOM, "Returns KPI Status.",
     		DataType.MEMBER, params);
     // KPIStatus(<String>)

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPITrendFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPITrendFunDef.java
@@ -28,7 +28,7 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class KPITrendFunDef extends AbstractFunctionDefinition {
 
     static final OperationAtom KPI_TREND_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("KPITrend");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.STRING, "Kpi") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "Kpi") };
     static final FunctionMetaData FUNCTION_META_DATA = new FunctionMetaDataR(KPI_TREND_INSTANCE_FUNCTION_ATOM, "Returns KPI Trend.",
     		DataType.MEMBER, params);
     // KPITrend(<String>)

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPIValueFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPIValueFunDef.java
@@ -28,7 +28,7 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class KPIValueFunDef extends AbstractFunctionDefinition {
 
     static final OperationAtom KPI_VALUE_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("KPIValue");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.STRING, "Kpi") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "Kpi") };
     static final FunctionMetaData FUNCTION_META_DATA = new FunctionMetaDataR(KPI_VALUE_INSTANCE_FUNCTION_ATOM, "Returns KPI Value.",
     		DataType.MEMBER, params);
     // KPIValue(<String>)

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPIWeightFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/kpi/KPIWeightFunDef.java
@@ -28,7 +28,7 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class KPIWeightFunDef extends AbstractFunctionDefinition {
 
     static final OperationAtom KPI_WEIGHT_INSTANCE_FUNCTION_ATOM = new FunctionOperationAtom("KPIWeight");
-    static FunctionParameterR[] params = { new FunctionParameterR(DataType.STRING, "Kpi") };
+    static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "Kpi") };
     static final FunctionMetaData FUNCTION_META_DATA = new FunctionMetaDataR(KPI_WEIGHT_INSTANCE_FUNCTION_ATOM, "Returns KPI Weight.",
     		DataType.MEMBER, params);
     // KPIWeight(<String>)

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/lastperiods/LastPeriodsResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/lastperiods/LastPeriodsResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,12 @@ import org.osgi.service.component.annotations.Component;
 public class LastPeriodsResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("LastPeriods");
     private static String DESCRIPTION = "Returns a set of members prior to and including a specified member.";
-    private static FunctionParameterR[] n = { new FunctionParameterR(DataType.NUMERIC, "Index") };
-    private static FunctionParameterR[] nm = { new FunctionParameterR(DataType.NUMERIC, "Index"),
-            new FunctionParameterR(DataType.MEMBER) };
-    // {"fxn", "fxnm"}
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, n);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, nm);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Index"),
+                    FunctionParameterR.param(DataType.MEMBER).asOptional() }).interfaceName(FunctionInterface.DATETIME);
 
     public LastPeriodsResolver() {
-        super(List.of(new LastPeriodsFunDef(functionMetaData1), new LastPeriodsFunDef(functionMetaData2)));
+        super(List.of(new LastPeriodsFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/leadlag/LagResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/leadlag/LagResolver.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.daanse.mdx.model.api.expression.operation.MethodOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -32,7 +33,7 @@ public class LagResolver extends AbstractFunctionDefinitionMultiResolver {
     // {"mmmn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ), new FunctionParameterR( DataType.NUMERIC ) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.NUMERIC) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public LagResolver() {
         super(List.of(new LeadLagFunDef(functionMetaData)));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/leadlag/LeadResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/leadlag/LeadResolver.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.daanse.mdx.model.api.expression.operation.MethodOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -32,7 +33,7 @@ public class LeadResolver extends AbstractFunctionDefinitionMultiResolver {
     //{"mmmn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ), new FunctionParameterR( DataType.NUMERIC ) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.NUMERIC) }).interfaceName(FunctionInterface.NAVIGATION);
 
 
     public LeadResolver() {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/level/member/MemberLevelFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/level/member/MemberLevelFunDef.java
@@ -20,6 +20,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
@@ -35,7 +36,7 @@ public class MemberLevelFunDef extends AbstractFunctionDefinition {
     static OperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Level");
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
-            "Returns a member's level.", DataType.LEVEL, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            "Returns a member's level.", DataType.LEVEL, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.METADATA);
 
     public MemberLevelFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/level/numeric/LevelNumberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/level/numeric/LevelNumberFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class LevelNumberFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Level_Number");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the level number of a member.", DataType.INTEGER,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.METADATA);
 
     public LevelNumberFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/level/numeric/LevelsNumericPropertyDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/level/numeric/LevelsNumericPropertyDef.java
@@ -38,7 +38,7 @@ public class LevelsNumericPropertyDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData levelsFunctionMetaData = new FunctionMetaDataR(methodOperationAtom,
             "Returns the level whose position in a hierarchy is specified by a numeric expression.",
-            DataType.LEVEL, new FunctionParameterR[] { new FunctionParameterR( DataType.HIERARCHY ), new FunctionParameterR( DataType.NUMERIC, "Ordinal" ) });
+            DataType.LEVEL, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY), FunctionParameterR.param(DataType.NUMERIC, "Ordinal") });
 
     public LevelsNumericPropertyDef() {
         super(levelsFunctionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/levels/string/LevelsStringFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/levels/string/LevelsStringFunDef.java
@@ -36,7 +36,7 @@ public class LevelsStringFunDef extends AbstractFunctionDefinition {
     static OperationAtom functionOperationAtom = new FunctionOperationAtom(LEVELS);
     static FunctionMetaData levelsFunctionMetaData = new FunctionMetaDataR(functionOperationAtom,
             "Returns the level whose name is specified by a string expression.", DataType.LEVEL,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String" )});
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String")});
 
     public LevelsStringFunDef() {
         super(levelsFunctionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/levels/string/LevelsStringPropertyDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/levels/string/LevelsStringPropertyDef.java
@@ -37,7 +37,7 @@ public class LevelsStringPropertyDef extends AbstractFunctionDefinition {
     static OperationAtom hierarchyMethodOperationAtom = new MethodOperationAtom(LEVELS);
     static FunctionMetaData hierarchyLevelsFunctionMetaData = new FunctionMetaDataR(hierarchyMethodOperationAtom,
             "Returns the level whose name is specified by a string expression.",
-            DataType.LEVEL, new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY ), new FunctionParameterR( DataType.STRING, "String" ) });
+            DataType.LEVEL, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY), FunctionParameterR.param(DataType.STRING, "String") });
 
     public LevelsStringPropertyDef() {
         super(hierarchyLevelsFunctionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegInterceptResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegInterceptResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,19 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class LinRegInterceptResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("LinRegIntercept");
     private static String DESCRIPTION = "Calculates the linear regression of a set and returns the value of b in the regression line y = ax + b.";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "NumericY") };
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "NumericY"), new FunctionParameterR(DataType.NUMERIC, "NumericX") };
-    // {"fnxn", "fnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xnn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC, "NumericY"),
+                    FunctionParameterR.param(DataType.NUMERIC, "NumericX").asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public LinRegInterceptResolver() {
-        super(List.of(new LinRegFunDef(functionMetaData, LinRegFunDef.INTERCEPT),
-                new LinRegFunDef(functionMetaData1, LinRegFunDef.INTERCEPT)));
+        super(List.of(new LinRegFunDef(functionMetaData, LinRegFunDef.INTERCEPT)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegPointResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegPointResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,20 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class LinRegPointResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("LinRegPoint");
     private static String DESCRIPTION = "Calculates the linear regression of a set and returns the value of y in the regression line y = ax + b.";
-    private static FunctionParameterR[] nxn = { new FunctionParameterR(DataType.NUMERIC, "xPoint"),
-            new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.NUMERIC, "Y") };
-    private static FunctionParameterR[] nxnn = { new FunctionParameterR(DataType.NUMERIC, "xPoint"),
-            new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.NUMERIC, "Y"),
-            new FunctionParameterR(DataType.NUMERIC, "X") };
-    // {"fnnxn", "fnnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, nxn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, nxnn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "xPoint"),
+                    FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.NUMERIC, "Y"),
+                    FunctionParameterR.param(DataType.NUMERIC, "X").asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public LinRegPointResolver() {
-        super(List.of(new PointFunDef(functionMetaData, LinRegFunDef.POINT),
-                new PointFunDef(functionMetaData1, LinRegFunDef.POINT)));
+        super(List.of(new PointFunDef(functionMetaData, LinRegFunDef.POINT)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegR2Resolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegR2Resolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,19 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class LinRegR2Resolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("LinRegR2");
     private static String DESCRIPTION = "Calculates the linear regression of a set and returns R2 (the coefficient of determination).";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Y") };
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Y"), new FunctionParameterR(DataType.NUMERIC, "X") };
-    // {"fnxn", "fnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xnn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC, "Y"),
+                    FunctionParameterR.param(DataType.NUMERIC, "X").asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public LinRegR2Resolver() {
-        super(List.of(new LinRegFunDef(functionMetaData, LinRegFunDef.R2),
-                new LinRegFunDef(functionMetaData1, LinRegFunDef.R2)));
+        super(List.of(new LinRegFunDef(functionMetaData, LinRegFunDef.R2)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegSlopeResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegSlopeResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,19 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class LinRegSlopeResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("LinRegSlope");
     private static String DESCRIPTION = "Calculates the linear regression of a set and returns the value of a in the regression line y = ax + b.";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Y") };
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Y"), new FunctionParameterR(DataType.NUMERIC, "X") };
-    // {"fnxn", "fnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xnn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC, "Y"),
+                    FunctionParameterR.param(DataType.NUMERIC, "X").asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public LinRegSlopeResolver() {
-        super(List.of(new LinRegFunDef(functionMetaData, LinRegFunDef.POINT),
-                new LinRegFunDef(functionMetaData1, LinRegFunDef.SLOPE)));
+        super(List.of(new LinRegFunDef(functionMetaData, LinRegFunDef.SLOPE)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegVarianceResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/linreg/LinRegVarianceResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,18 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class LinRegVarianceResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("LinRegVariance");
     private static String DESCRIPTION = "Calculates the linear regression of a set and returns the variance associated with the regression line y = ax + b.";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.NUMERIC, "Y") };
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.NUMERIC, "Y"),
-            new FunctionParameterR(DataType.NUMERIC, "X") };
-    // {"fnxn", "fnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xnn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC, "Y"),
+                    FunctionParameterR.param(DataType.NUMERIC, "X").asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public LinRegVarianceResolver() {
-        super(List.of(new LinRegFunDef(functionMetaData, LinRegFunDef.VARIANCE),
-                new LinRegFunDef(functionMetaData1, LinRegFunDef.VARIANCE)));
+        super(List.of(new LinRegFunDef(functionMetaData, LinRegFunDef.VARIANCE)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/logical/IsEmptyFunctionResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/logical/IsEmptyFunctionResolver.java
@@ -32,11 +32,11 @@ public class IsEmptyFunctionResolver extends AbstractFunctionDefinitionMultiReso
 
     private static FunctionMetaData functionMetaDataString = new FunctionMetaDataR(fAtom,
         "Determines if an expression evaluates to the empty cell value.",
-        DataType.LOGICAL, new FunctionParameterR[]{ new FunctionParameterR(DataType.STRING, "Value")});
+        DataType.LOGICAL, new FunctionParameterR[]{ FunctionParameterR.param(DataType.STRING, "Value")});
 
     private static FunctionMetaData functionMetaDataNumeric = new FunctionMetaDataR(fAtom,
         "Determines if an expression evaluates to the empty cell value.",
-        DataType.LOGICAL, new FunctionParameterR[]{ new FunctionParameterR(DataType.NUMERIC, "Value")});
+        DataType.LOGICAL, new FunctionParameterR[]{ FunctionParameterR.param(DataType.NUMERIC, "Value")});
 
     public IsEmptyFunctionResolver() {
         super(List.of(new IsEmptyFunDef(functionMetaDataString), new IsEmptyFunDef(functionMetaDataNumeric)));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/logical/IsEmptyPostfixResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/logical/IsEmptyPostfixResolver.java
@@ -36,7 +36,7 @@ public class IsEmptyPostfixResolver extends AbstractFunctionDefinitionMultiResol
 
     private static FunctionMetaData postfixMetaDataTuple = new FunctionMetaDataR(pAtom,
         "A shortcut function for the PeriodsToDate function that specifies the level to be Month.",
-        DataType.LOGICAL, new FunctionParameterR[]{ new FunctionParameterR( DataType.TUPLE)});
+        DataType.LOGICAL, new FunctionParameterR[]{ FunctionParameterR.param(DataType.TUPLE)});
 
     public IsEmptyPostfixResolver() {
         super(List.of(new IsEmptyFunDef(postfixMetaDataMember), new IsEmptyFunDef(postfixMetaDataTuple)));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/logical/IsNullResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/logical/IsNullResolver.java
@@ -32,16 +32,16 @@ public class IsNullResolver extends AbstractFunctionDefinitionMultiResolver {
     private static OperationAtom atom = new PostfixOperationAtom("IS NULL");
 
     private static FunctionMetaData functionMetaDataWithMember = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) });
 
     private static FunctionMetaData functionMetaDataWithLevel = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.LEVEL ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) });
 
     private static FunctionMetaData functionMetaDataWithHierrchy = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) });
 
     private static FunctionMetaData functionMetaDataWithDimension = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.DIMENSION ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.DIMENSION) });
 
     public IsNullResolver() {
         super(List.of(new IsNullFunDef(functionMetaDataWithMember), new IsNullFunDef(functionMetaDataWithLevel),

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/logical/IsResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/logical/IsResolver.java
@@ -33,19 +33,19 @@ public class IsResolver extends AbstractFunctionDefinitionMultiResolver {
     //{"ibmm", "ibll", "ibhh", "ibdd", "ibtt"}
 
     private static FunctionMetaData functionMetaDataWithMember = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER, "Member1" ), new FunctionParameterR( DataType.MEMBER, "Member2" )});
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER, "Member1"), FunctionParameterR.param(DataType.MEMBER, "Member2")});
 
     private static FunctionMetaData functionMetaDataWithLevel = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.LEVEL, "Level1" ), new FunctionParameterR( DataType.LEVEL, "Level2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL, "Level1"), FunctionParameterR.param(DataType.LEVEL, "Level2") });
 
     private static FunctionMetaData functionMetaDataWithHierrchy = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY, "Hierarchy1" ), new FunctionParameterR( DataType.HIERARCHY, "Hierarchy2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY, "Hierarchy1"), FunctionParameterR.param(DataType.HIERARCHY, "Hierarchy2") });
 
     private static FunctionMetaData functionMetaDataWithDimension = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.DIMENSION, "Dimension1" ), new FunctionParameterR( DataType.DIMENSION, "Dimension2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.DIMENSION, "Dimension1"), FunctionParameterR.param(DataType.DIMENSION, "Dimension2") });
 
     private static FunctionMetaData functionMetaDataWithTuple = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.TUPLE, "Tuple1" ), new FunctionParameterR( DataType.TUPLE, "Tuple2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.TUPLE, "Tuple1"), FunctionParameterR.param(DataType.TUPLE, "Tuple2") });
 
     public IsResolver() {
         super(List.of(new IsFunDef(functionMetaDataWithMember), new IsFunDef(functionMetaDataWithLevel),

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/AncestorsResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/AncestorsResolver.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -33,10 +34,10 @@ public class AncestorsResolver extends AbstractFunctionDefinitionMultiResolver {
     //{"fxml", "fxmn"}
 
     private static FunctionMetaData functionMetaDataWithLevel = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ), new FunctionParameterR( DataType.LEVEL ) });
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.LEVEL) }).interfaceName(FunctionInterface.NAVIGATION);
 
     private static FunctionMetaData functionMetaDataWithNumeric = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ), new FunctionParameterR( DataType.NUMERIC ) });
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.NUMERIC) }).interfaceName(FunctionInterface.NAVIGATION);
 
 
     public AncestorsResolver() {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/cousin/CousinFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/cousin/CousinFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class CousinFunDef extends AbstractFunctionDefinition {
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtomCousin,
             "Returns the member with the same relative position under <ancestor member> as the member specified.",
             DataType.MEMBER,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER, "Member1"), new FunctionParameterR( DataType.MEMBER, "Member2" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER, "Member1"), FunctionParameterR.param(DataType.MEMBER, "Member2") }).interfaceName(FunctionInterface.NAVIGATION);
 
     public CousinFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/datamember/DataMemberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/datamember/DataMemberFunDef.java
@@ -21,6 +21,7 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.element.Member;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedMemberCalc;
@@ -32,7 +33,7 @@ public class DataMemberFunDef extends AbstractFunctionDefinition {
     static OperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("DataMember");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the system-generated data member that is associated with a nonleaf member of a dimension.",
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public DataMemberFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/defaultmember/DefaultMemberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/defaultmember/DefaultMemberFunDef.java
@@ -22,6 +22,7 @@ import org.eclipse.daanse.olap.api.calc.HierarchyCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.element.Hierarchy;
 import org.eclipse.daanse.olap.api.element.Member;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.calc.base.nested.AbstractProfilingNestedMemberCalc;
@@ -32,7 +33,7 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 public class DefaultMemberFunDef extends AbstractFunctionDefinition {
     static OperationAtom functionAtomDefaultMember = new PlainPropertyOperationAtom("DefaultMember");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtomDefaultMember,
-            "Returns the default member of a hierarchy.", DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY ) });
+            "Returns the default member of a hierarchy.", DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public DefaultMemberFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/defaultmember/NonFunctionDefaultMemberResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/defaultmember/NonFunctionDefaultMemberResolver.java
@@ -15,6 +15,7 @@ package org.eclipse.daanse.olap.function.def.member.defaultmember;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.PlainPropertyOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
@@ -29,7 +30,7 @@ public class NonFunctionDefaultMemberResolver extends NonFunctionResolver {
         // implicit cast to hierarchy, and we create a FunInfo for
         // documentation & backwards compatibility.
         super(new FunctionMetaDataR(new PlainPropertyOperationAtom("DefaultMember"), "Returns the default member of a dimension.",
-                DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.DIMENSION) }));
+                DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.DIMENSION) }).interfaceName(FunctionInterface.NAVIGATION));
     }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/firstchild/FirstChildFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/firstchild/FirstChildFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class FirstChildFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("FirstChild");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the first child of a member.", DataType.MEMBER,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public FirstChildFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/firstsibling/FirstSiblingFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/firstsibling/FirstSiblingFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class FirstSiblingFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("FirstSibling");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the first child of the parent of a member.", DataType.MEMBER,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public FirstSiblingFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/lastchild/LastChildFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/lastchild/LastChildFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class LastChildFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("LastChild");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the last child of a member.", DataType.MEMBER,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public LastChildFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/lastsibling/LastSiblingFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/lastsibling/LastSiblingFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class LastSiblingFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("LastSibling");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the last child of the parent of a member.", DataType.MEMBER,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public LastSiblingFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/memberorderkey/MemberOrderKeyFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/memberorderkey/MemberOrderKeyFunDef.java
@@ -28,7 +28,7 @@ public class MemberOrderKeyFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("OrderKey");
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
-            "Returns the member order key.", DataType.VALUE, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
+            "Returns the member order key.", DataType.VALUE, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) });
 
     /**
      * Creates the singleton MemberOrderKeyFunDef.

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/members/MembersFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/members/MembersFunDef.java
@@ -29,7 +29,7 @@ public class MembersFunDef extends AbstractFunctionDefinition {
     static FunctionOperationAtom functionOperationAtom = new FunctionOperationAtom("Members");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionOperationAtom,
             "Returns the last child of the parent of a member.", DataType.MEMBER,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "String" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String") });
 
     public MembersFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/members/NonFunctionMembersResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/members/NonFunctionMembersResolver.java
@@ -25,6 +25,6 @@ import org.osgi.service.component.annotations.Component;
 public class NonFunctionMembersResolver extends NonFunctionResolver {
     public NonFunctionMembersResolver() {
         super(new FunctionMetaDataR(new PlainPropertyOperationAtom("Members"), "Returns the set of members in a dimension.",
-                DataType.SET, new FunctionParameterR[] { new FunctionParameterR(DataType.DIMENSION) }));
+                DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.DIMENSION) }));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/namedsetcurrentordinal/NamedSetCurrentOrdinalFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/namedsetcurrentordinal/NamedSetCurrentOrdinalFunDef.java
@@ -34,7 +34,7 @@ public class NamedSetCurrentOrdinalFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the ordinal of the current iteration through a named set.",
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.SET ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) });
 
     public NamedSetCurrentOrdinalFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/nextmember/NextMemberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/nextmember/NextMemberFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class NextMemberFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("NextMember");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the next member in the level that contains a specified member.",
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public NextMemberFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/parentcalc/ParentFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/parentcalc/ParentFunDef.java
@@ -20,6 +20,7 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.element.Member;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,7 +32,7 @@ public class ParentFunDef extends AbstractFunctionDefinition {
     // <Member>.Parent
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Parent");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
-            "Returns the parent of a member.", DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
+            "Returns the parent of a member.", DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public ParentFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/prevmember/PrevMemberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/prevmember/PrevMemberFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class PrevMemberFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("PrevMember");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the previous member in the level that contains a specified member.",
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public PrevMemberFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/strtomember/StrToMemberFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/strtomember/StrToMemberFunDef.java
@@ -31,7 +31,7 @@ public class StrToMemberFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Returns a member from a unique name String in MDX format.", DataType.MEMBER,
-            new FunctionParameterR[] { new FunctionParameterR(DataType.STRING, "String") });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String") });
 
     public StrToMemberFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/member/validmeasure/ValidMeasureFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/member/validmeasure/ValidMeasureFunDef.java
@@ -31,7 +31,7 @@ public class ValidMeasureFunDef extends AbstractFunctionDefinition
     static OperationAtom functionAtom = new FunctionOperationAtom("ValidMeasure");
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom, "Returns a valid measure in a virtual cube by forcing inapplicable dimensions to their top level.",
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(DataType.TUPLE) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.TUPLE) });
 
     public ValidMeasureFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/minmax/MaxResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/minmax/MaxResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,12 @@ import org.osgi.service.component.annotations.Component;
 public class MaxResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Max");
     private static String DESCRIPTION = "Returns the maximum value of a numeric expression evaluated over a set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
-    // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC).asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public MaxResolver() {
-        super(List.of(new MinMaxFunDef(functionMetaData), new MinMaxFunDef(functionMetaData1)));
+        super(List.of(new MinMaxFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/minmax/MinResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/minmax/MinResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,12 @@ import org.osgi.service.component.annotations.Component;
 public class MinResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Min");
     private static String DESCRIPTION = "Returns the minimum value of a numeric expression evaluated over a set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
-    // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET),
+                    FunctionParameterR.param(DataType.NUMERIC).asOptional() }).interfaceName(FunctionInterface.STATISTICAL);
 
     public MinResolver() {
-        super(List.of(new MinMaxFunDef(functionMetaData), new MinMaxFunDef(functionMetaData1)));
+        super(List.of(new MinMaxFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/name/dimension/NameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/name/dimension/NameFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.DimensionCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class NameFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Name");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the name of a dimension.", DataType.STRING,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.DIMENSION ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.DIMENSION) }).interfaceName(FunctionInterface.METADATA);
 
     public NameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/name/hierarchy/NameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/name/hierarchy/NameFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.HierarchyCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class NameFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Name");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the name of a hierarchy.", DataType.STRING,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) }).interfaceName(FunctionInterface.METADATA);
 
     public NameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/name/level/NameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/name/level/NameFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.LevelCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class NameFunDef extends AbstractFunctionDefinition {
     // <Level>.Name
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Name");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
-            "Returns the name of a level.", DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.LEVEL ) });
+            "Returns the name of a level.", DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) }).interfaceName(FunctionInterface.METADATA);
 
     public NameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/name/member/NameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/name/member/NameFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class NameFunDef extends AbstractFunctionDefinition {
     // <Member>.Name
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Name");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
-            "Returns the name of a member.", DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            "Returns the name of a member.", DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.METADATA);
 
     public NameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nativizeset/NativizeSetResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nativizeset/NativizeSetResolver.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.Component;
 public class NativizeSetResolver  extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("NativizeSet");
     private static String DESCRIPTION = "Tries to natively evaluate <Set>.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
+    private static FunctionParameterR[] x = { FunctionParameterR.param(DataType.SET) };
     // {"fxx"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nonempty/NonEmptyResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nonempty/NonEmptyResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class NonEmptyResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("NonEmpty");
     private static String DESCRIPTION = "Returns the set of tuples that are not empty from a specified set, based on the cross product of the specified set with a second set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xx = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2") };
+    private static FunctionParameterR[] xx = { FunctionParameterR.param(DataType.SET, "Set1"),
+            FunctionParameterR.param(DataType.SET, "Set2").asOptional() };
     // {"fxx", "fxxx"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION, DataType.SET,
-            x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xx);
+            xx).interfaceName(FunctionInterface.FILTER);
 
     public NonEmptyResolver() {
-        super(List.of(new NonEmptyFunDef(functionMetaData), new NonEmptyFunDef(functionMetaData1)));
+        super(List.of(new NonEmptyFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nonemptycrossjoin/NonEmptyCrossJoinResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nonemptycrossjoin/NonEmptyCrossJoinResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,13 +29,13 @@ import org.osgi.service.component.annotations.Component;
 public class NonEmptyCrossJoinResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("NonEmptyCrossJoin");
     private static String DESCRIPTION = "Returns the cross product of two sets, excluding empty tuples and tuples without associated fact table data.";
-    private static FunctionParameterR set1 = new FunctionParameterR(DataType.SET, "Set1");
-    private static FunctionParameterR set2 = new FunctionParameterR(DataType.SET, "Set2");
+    private static FunctionParameterR set1 = FunctionParameterR.param(DataType.SET, "Set1");
+    private static FunctionParameterR set2 = FunctionParameterR.param(DataType.SET, "Set2");
     private static FunctionParameterR[] xx = { set1, set2};
     // {"fxxx"}
     
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xx);
+            DataType.SET, xx).interfaceName(FunctionInterface.FILTER);
 
     public NonEmptyCrossJoinResolver() {
         super(List.of(new NonEmptyCrossJoinFunDef(functionMetaData)));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nonstandard/CachedExistsFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nonstandard/CachedExistsFunDef.java
@@ -34,7 +34,7 @@ public class CachedExistsFunDef extends AbstractFunctionDefinition {
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Returns tuples from a non-dynamic <Set> that exists in the specified <Tuple>.  This function will build a query level cache named <String> based on the <Tuple> type.",
             DataType.SET,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.SET ), new FunctionParameterR( DataType.TUPLE ), new FunctionParameterR( DataType.STRING, "String") });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.TUPLE), FunctionParameterR.param(DataType.STRING, "String") });
 
     CachedExistsFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nonstandard/CalculatedChildFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nonstandard/CalculatedChildFunDef.java
@@ -32,8 +32,8 @@ public class CalculatedChildFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(methodOperationAtom,
             "Returns an existing calculated child member with name <String> from the specified <Member>.",
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ),
-                    new FunctionParameterR( DataType.STRING, "String" ) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER),
+                    FunctionParameterR.param(DataType.STRING, "String") });
 
     CalculatedChildFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nonstandard/CastResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nonstandard/CastResolver.java
@@ -13,18 +13,22 @@
  */
 package org.eclipse.daanse.olap.function.def.nonstandard;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.query.component.Literal;
 import org.eclipse.daanse.olap.exceptions.CastInvalidTypeException;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.eclipse.daanse.olap.query.base.Expressions;
 import org.osgi.service.component.annotations.Component;
@@ -33,14 +37,14 @@ import org.osgi.service.component.annotations.Component;
 public class CastResolver extends NoExpressionRequiredFunctionResolver {
 
     @Override
-    public FunctionDefinition resolve(
-        Expression[] args, Validator validator, List<Conversion> conversions)
+    public Optional<FunctionResolutionResult> resolve(
+        Expression[] args, Validator validator)
     {
         if (args.length != 2) {
-            return null;
+            return Optional.empty();
         }
         if (!(args[1] instanceof Literal literal)) {
-            return null;
+            return Optional.empty();
         }
         String typeName = (String) literal.getValue();
         DataType returnCategory;
@@ -59,11 +63,21 @@ public class CastResolver extends NoExpressionRequiredFunctionResolver {
 
         FunctionMetaData functionMetaData = new FunctionMetaDataR(CastFunDef.functionAtom, "Converts values to another type.",
                 returnCategory, Expressions.functionParameterOf(args));
-        return new CastFunDef(functionMetaData);
+        return Optional.of(FunctionResolutionResultR.of(new CastFunDef(functionMetaData), List.<Conversion>of()));
     }
 
     @Override
     public OperationAtom getFunctionAtom() {
         return CastFunDef.functionAtom;
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+        FunctionMetaDataR.of(CastFunDef.functionAtom, "Converts values to another type.", DataType.VALUE,
+            param(DataType.VALUE),
+            param(DataType.STRING, "Type_Name").reserved("String", "Numeric", "Integer", "Boolean")));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nthquartile/FirstQResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nthquartile/FirstQResolver.java
@@ -17,26 +17,27 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
 import org.eclipse.daanse.olap.function.core.resolver.AbstractFunctionDefinitionMultiResolver;
+import org.osgi.service.component.annotations.Component;
 
+@Component(service = FunctionResolver.class)
 public class FirstQResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("FirstQ");
     private static String DESCRIPTION = "Returns the 1st quartile value of a numeric expression evaluated over a set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Range") };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Range").asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public FirstQResolver() {
-        super(List.of(new NthQuartileFunDef(functionMetaData), new NthQuartileFunDef(functionMetaData1)));
+        super(List.of(new NthQuartileFunDef(functionMetaData)));
     }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/nthquartile/ThirdQResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/nthquartile/ThirdQResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,15 @@ import org.osgi.service.component.annotations.Component;
 public class ThirdQResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("ThirdQ");
     private static String DESCRIPTION = "Returns the 3rd quartile value of a numeric expression evaluated over a set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.NUMERIC, "Range") };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Range").asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public ThirdQResolver() {
-        super(List.of(new NthQuartileFunDef(functionMetaData), new NthQuartileFunDef(functionMetaData1)));
+        super(List.of(new NthQuartileFunDef(functionMetaData)));
     }
 
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/numeric/ordinal/OrdinalFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/numeric/ordinal/OrdinalFunDef.java
@@ -29,7 +29,7 @@ public class OrdinalFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Ordinal");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the zero-based ordinal value associated with a level.", DataType.NUMERIC,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.LEVEL ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) });
 
     public OrdinalFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/numeric/value/ValueFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/numeric/value/ValueFunDef.java
@@ -28,7 +28,7 @@ public class ValueFunDef extends AbstractFunctionDefinition {
     // <Measure>.Value
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Value");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
-            "Returns the value of a measure.", DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
+            "Returns the value of a measure.", DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) });
 
     public ValueFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/openingclosingperiod/ClosingPeriodResolved.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/openingclosingperiod/ClosingPeriodResolved.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -33,14 +34,14 @@ public class ClosingPeriodResolved extends AbstractFunctionDefinitionMultiResolv
     // {"fm", "fml", "fmlm", "fmm"}
 
     private static FunctionMetaData functionMetaDataWithoutParam = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] {});
+            DataType.MEMBER, new FunctionParameterR[] {}).interfaceName(FunctionInterface.DATETIME);
     private static FunctionMetaData functionMetaDataWithLevel = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.LEVEL) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) }).interfaceName(FunctionInterface.DATETIME);
     private static FunctionMetaData functionMetaDataWithLevelMember = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.LEVEL),
-                    new FunctionParameterR(DataType.MEMBER) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL),
+                    FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.DATETIME);
     private static FunctionMetaData functionMetaDataWithMember = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.MEMBER) });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.DATETIME);
 
     public ClosingPeriodResolved() {
         super(List.of(new OpeningClosingPeriodFunDef(functionMetaDataWithoutParam, false),

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/openingclosingperiod/OpeningPeriodResolved.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/openingclosingperiod/OpeningPeriodResolved.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -32,17 +33,11 @@ public class OpeningPeriodResolved extends AbstractFunctionDefinitionMultiResolv
     private static String DESCRIPTION = "Returns the first descendant of a member at a level.";
     // {"fm", "fml", "fmlm"}
 
-    private static FunctionMetaData functionMetaDataWithoutParam = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] {});
-    private static FunctionMetaData functionMetaDataWithLevel = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.LEVEL) });
-    private static FunctionMetaData functionMetaDataWithLevelMember = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.LEVEL),
-                    new FunctionParameterR(DataType.MEMBER) });
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL).asOptional(),
+                    FunctionParameterR.param(DataType.MEMBER).asOptional() }).interfaceName(FunctionInterface.DATETIME);
 
     public OpeningPeriodResolved() {
-        super(List.of(new OpeningClosingPeriodFunDef(functionMetaDataWithoutParam, true),
-                new OpeningClosingPeriodFunDef(functionMetaDataWithLevel, true),
-                new OpeningClosingPeriodFunDef(functionMetaDataWithLevelMember, true)));
+        super(List.of(new OpeningClosingPeriodFunDef(functionMetaData, true)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/and/AndOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/and/AndOperatorDef.java
@@ -30,7 +30,7 @@ public class AndOperatorDef extends AbstractFunctionDefinition {
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("AND");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom,
             "Returns the conjunction of two conditions.", DataType.LOGICAL,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.LOGICAL, "Condition1" ), new FunctionParameterR( DataType.LOGICAL, "Condition2" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.LOGICAL, "Condition1"), FunctionParameterR.param(DataType.LOGICAL, "Condition2") });
 
     public AndOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/divide/DivideOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/divide/DivideOperatorDef.java
@@ -30,8 +30,8 @@ public class DivideOperatorDef extends AbstractFunctionDefinition {
     // <Numeric Expression> / <Numeric Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("/");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Divides two numbers.",
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Numeric1" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Numeric2" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric2") });
 
     public DivideOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualOperatorDef.java
@@ -30,7 +30,7 @@ public class EqualOperatorDef extends AbstractFunctionDefinition {
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("=");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom,
             "Returns whether two expressions are equal.", DataType.LOGICAL,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Numeric1" ), new FunctionParameterR( DataType.NUMERIC, "Numeric2" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"), FunctionParameterR.param(DataType.NUMERIC, "Numeric2") });
 
     public EqualOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualStringOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualStringOperatorDef.java
@@ -29,7 +29,7 @@ public class EqualStringOperatorDef extends AbstractFunctionDefinition {
     // <String Expression> = <String Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("=");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Returns whether two expressions are equal.",
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String1" ), new FunctionParameterR( DataType.STRING, "String2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String1"), FunctionParameterR.param(DataType.STRING, "String2") });
 
     public EqualStringOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOperatorDef.java
@@ -29,8 +29,8 @@ public class GreaterOperatorDef extends AbstractFunctionDefinition {
     // <Numeric Expression> > <Numeric Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom(">");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Returns whether an expression is greater than another.",
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC, "Numeric1" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Numeric2" )  });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric2")  });
 
     public GreaterOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOrEqualOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOrEqualOperatorDef.java
@@ -29,7 +29,7 @@ public class GreaterOrEqualOperatorDef extends AbstractFunctionDefinition {
     // <Numeric Expression> >= <Numeric Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom(">=");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Returns whether an expression is greater than or equal to another.",
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC, "Numeric1" ), new FunctionParameterR( DataType.NUMERIC, "Numeric2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"), FunctionParameterR.param(DataType.NUMERIC, "Numeric2") });
 
     public GreaterOrEqualOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOrEqualStringOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOrEqualStringOperatorDef.java
@@ -29,8 +29,8 @@ public class GreaterOrEqualStringOperatorDef extends AbstractFunctionDefinition 
     // <String Expression> >= <String Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom(">=");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Returns whether an expression is greater than or equal to another.",
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String1" ),
-                    new FunctionParameterR( DataType.STRING, "String2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String1"),
+                    FunctionParameterR.param(DataType.STRING, "String2") });
 
     public GreaterOrEqualStringOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterStringOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterStringOperatorDef.java
@@ -30,7 +30,7 @@ public class GreaterStringOperatorDef extends AbstractFunctionDefinition {
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom(">");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom,
             "Returns whether an expression is greater than another.", DataType.LOGICAL,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String1" ), new FunctionParameterR( DataType.STRING, "String2" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String1"), FunctionParameterR.param(DataType.STRING, "String2") });
 
     public GreaterStringOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessOperatorDef.java
@@ -29,8 +29,8 @@ public class LessOperatorDef extends AbstractFunctionDefinition {
     // <Numeric Expression> < <Numeric Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("<");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Returns whether an expression is less than another.",
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC, "Numeric1" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Numeric2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric2") });
 
     public LessOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessOrEqualOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessOrEqualOperatorDef.java
@@ -29,8 +29,8 @@ public class LessOrEqualOperatorDef extends AbstractFunctionDefinition {
     // <Numeric Expression> <= <Numeric Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("<=");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Returns whether an expression is less than or equal to another.",
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC, "Numeric1" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Numeric2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric2") });
 
     public LessOrEqualOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessOrEqualStringOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessOrEqualStringOperatorDef.java
@@ -30,7 +30,7 @@ public class LessOrEqualStringOperatorDef extends AbstractFunctionDefinition {
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("<=");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom,
             "Returns whether an expression is less than or equal to another.", DataType.LOGICAL,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String1" ), new FunctionParameterR( DataType.STRING, "String2" )});
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String1"), FunctionParameterR.param(DataType.STRING, "String2")});
 
     public LessOrEqualStringOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessStringOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/less/LessStringOperatorDef.java
@@ -29,8 +29,8 @@ public class LessStringOperatorDef extends AbstractFunctionDefinition {
     // <String Expression> < <String Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("<");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Returns whether an expression is less than another.",
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String1" ),
-                    new FunctionParameterR( DataType.STRING, "String2" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String1"),
+                    FunctionParameterR.param(DataType.STRING, "String2") });
 
     public LessStringOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusOperatorDef.java
@@ -29,8 +29,8 @@ public class MinusOperatorDef extends AbstractFunctionDefinition {
     // <Numeric Expression> - <Numeric Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("-");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Subtracts two numbers.",
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC, "Numeric1" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Numeric2" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric2") });
 
     public MinusOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusPrefixOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusPrefixOperatorDef.java
@@ -29,7 +29,7 @@ public class MinusPrefixOperatorDef extends AbstractFunctionDefinition {
     // - <Numeric Expression>
     static PrefixOperationAtom prefixOperationAtom = new PrefixOperationAtom("-");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(prefixOperationAtom,
-            "Returns the negative of a number.", DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC ) });
+            "Returns the negative of a number.", DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC) });
 
     public MinusPrefixOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/multiply/MultiplyOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/multiply/MultiplyOperatorDef.java
@@ -29,8 +29,8 @@ public class MultiplyOperatorDef extends AbstractFunctionDefinition {
     // <Numeric Expression> * <Numeric Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("*");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Multiplies two numbers.",
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC, "Numeric1" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Numeric2" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric2") });
 
     public MultiplyOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/not/NotPrefixOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/not/NotPrefixOperatorDef.java
@@ -30,7 +30,7 @@ public class NotPrefixOperatorDef extends AbstractFunctionDefinition {
     static PrefixOperationAtom prefixOperationAtom = new PrefixOperationAtom("NOT");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(prefixOperationAtom,
             "Returns the negation of a condition.", DataType.LOGICAL,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.LOGICAL, "Condition" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.LOGICAL, "Condition") });
 
     public NotPrefixOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualOperatorDef.java
@@ -30,8 +30,8 @@ public class NotEqualOperatorDef extends AbstractFunctionDefinition {
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("<>");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom,
             "Returns whether two expressions are not equal.", DataType.LOGICAL,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Numeric1" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Numeric2" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric2") });
 
     public NotEqualOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualStringOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualStringOperatorDef.java
@@ -30,7 +30,7 @@ public class NotEqualStringOperatorDef extends AbstractFunctionDefinition {
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("<>");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom,
             "Returns whether two expressions are not equal.", DataType.LOGICAL,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "String1" ), new FunctionParameterR( DataType.STRING, "String2"  )});
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String1"), FunctionParameterR.param(DataType.STRING, "String2")});
 
     public NotEqualStringOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/or/OrOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/or/OrOperatorDef.java
@@ -29,8 +29,8 @@ public class OrOperatorDef extends AbstractFunctionDefinition {
     // <Logical Expression> OR <Logical Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("OR");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Returns the disjunction of two conditions.",
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR(  DataType.LOGICAL, "Condition1" ),
-                    new FunctionParameterR( DataType.LOGICAL, "Condition2" )});
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.LOGICAL, "Condition1"),
+                    FunctionParameterR.param(DataType.LOGICAL, "Condition2")});
 
     public OrOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/or/OrStringOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/or/OrStringOperatorDef.java
@@ -29,8 +29,8 @@ public class OrStringOperatorDef extends AbstractFunctionDefinition {
     // <String Expression> || <String Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("||");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Concatenates two strings.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String1" ),
-                    new FunctionParameterR( DataType.STRING, "String2" )});
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String1"),
+                    FunctionParameterR.param(DataType.STRING, "String2")});
 
     public OrStringOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/plus/PlusOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/plus/PlusOperatorDef.java
@@ -29,8 +29,8 @@ public class PlusOperatorDef extends AbstractFunctionDefinition{
     // <Numeric Expression> + <Numeric Expression>
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("+");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom, "Adds two numbers.",
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR(  DataType.NUMERIC, "Numeric1" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Numeric1" )});
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Numeric1"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Numeric1")});
 
     public PlusOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/xor/XorOperatorDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/operators/xor/XorOperatorDef.java
@@ -30,7 +30,7 @@ public class XorOperatorDef extends AbstractFunctionDefinition {
     static InfixOperationAtom infixOperationAtom = new InfixOperationAtom("XOR");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(infixOperationAtom,
             "Returns whether two conditions are mutually exclusive.", DataType.LOGICAL,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.LOGICAL, "Condition1" ), new FunctionParameterR( DataType.LOGICAL, "Condition1" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.LOGICAL, "Condition1"), FunctionParameterR.param(DataType.LOGICAL, "Condition1") });
 
     public XorOperatorDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/order/OrderResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/order/OrderResolver.java
@@ -13,16 +13,23 @@
  */
 package org.eclipse.daanse.olap.function.def.order;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.fun.sort.Sorter.SorterFlag;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.osgi.service.component.annotations.Component;
 
@@ -37,24 +44,25 @@ public class OrderResolver  extends NoExpressionRequiredFunctionResolver {
     }
 
     @Override
-    public FunctionDefinition resolve( Expression[] args, Validator validator, List<Conversion> conversions ) {
+    public Optional<FunctionResolutionResult> resolve( Expression[] args, Validator validator ) {
+      List<Conversion> conversions = new ArrayList<>();
       OrderResolver.argTypes = new FunctionParameterR[args.length];
 
       if ( args.length < 2 ) {
-        return null;
+        return Optional.empty();
       }
       // first arg must be a set
       if ( !validator.canConvert( 0, args[0], DataType.SET, conversions ) ) {
-        return null;
+        return Optional.empty();
       }
-      OrderResolver.argTypes[0] = new FunctionParameterR(DataType.SET);
+      OrderResolver.argTypes[0] = FunctionParameterR.param(DataType.SET);
       // after fist args, should be: value [, symbol]
       int i = 1;
       while ( i < args.length ) {
         if ( !validator.canConvert( i, args[i], DataType.VALUE, conversions ) ) {
-          return null;
+          return Optional.empty();
         } else {
-          OrderResolver.argTypes[i] = new FunctionParameterR(DataType.VALUE);
+          OrderResolver.argTypes[i] = FunctionParameterR.param(DataType.VALUE);
           i++;
         }
         // if symbol is not specified, skip to the next
@@ -64,13 +72,13 @@ public class OrderResolver  extends NoExpressionRequiredFunctionResolver {
           if ( !validator.canConvert( i, args[i], DataType.SYMBOL, conversions ) ) {
             // continue, will default sort flag for prev arg to ASC
           } else {
-            OrderResolver.argTypes[i] = new FunctionParameterR(DataType.SYMBOL);
+            OrderResolver.argTypes[i] = FunctionParameterR.param(DataType.SYMBOL);
             i++;
           }
         }
       }
 
-      return new OrderFunDef( OrderResolver.argTypes );
+      return Optional.of(FunctionResolutionResultR.of(new OrderFunDef( OrderResolver.argTypes ), conversions));
     }
 
     @Override
@@ -84,5 +92,19 @@ public class OrderResolver  extends NoExpressionRequiredFunctionResolver {
     @Override
     public OperationAtom getFunctionAtom() {
         return OrderFunDef.functionAtom;
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+        FunctionMetaDataR.of(OrderFunDef.functionAtom,
+            "Arranges members of a set, optionally preserving or breaking the hierarchy.", DataType.SET,
+            param(DataType.SET),
+            param(DataType.VALUE, "Value_Expression").repeatable(1),
+            param(DataType.SYMBOL, "Sort_Flag").repeatable(1).asSkippable()
+                .reserved("ASC", "DESC", "BASC", "BDESC")
+                .describedAs("ASC (default), DESC, BASC or BDESC — B-variants break the hierarchy.")));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
   }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/parallelperiod/ParallelPeriodResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/parallelperiod/ParallelPeriodResolver.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -32,21 +33,12 @@ public class ParallelPeriodResolver extends AbstractFunctionDefinitionMultiResol
     private static String DESCRIPTION = "Returns a member from a prior period in the same relative position as a specified member.";
     // {"fm", "fml", "fmln", "fmlnm"}
 
-    private static FunctionMetaData functionMetaDataWithoutParam = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] {});
-    private static FunctionMetaData functionMetaDataWithLevel = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.LEVEL) });
-    private static FunctionMetaData functionMetaDataWithLevelNumeric = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.LEVEL),
-                    new FunctionParameterR(DataType.NUMERIC) });
-    private static FunctionMetaData functionMetaDataWithLevelNumericMember = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.LEVEL),
-                    new FunctionParameterR(DataType.NUMERIC), new FunctionParameterR(DataType.MEMBER) });
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL).asOptional(),
+                    FunctionParameterR.param(DataType.NUMERIC).asOptional(),
+                    FunctionParameterR.param(DataType.MEMBER).asOptional() }).interfaceName(FunctionInterface.DATETIME);
 
     public ParallelPeriodResolver() {
-        super(List.of(new ParallelPeriodFunDef(functionMetaDataWithoutParam),
-                new ParallelPeriodFunDef(functionMetaDataWithLevel),
-                new ParallelPeriodFunDef(functionMetaDataWithLevelNumeric),
-                new ParallelPeriodFunDef(functionMetaDataWithLevelNumericMember)));
+        super(List.of(new ParallelPeriodFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/parameter/ParamRefResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/parameter/ParamRefResolver.java
@@ -35,7 +35,7 @@ public class ParamRefResolver  extends AbstractMetaDataMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("ParamRef");
     private static String DESCRIPTION = "Returns the current value of this parameter. If it is null, returns the default value.";
     
-    private static FunctionParameterR[] S = { new FunctionParameterR(DataType.STRING, "Name") };
+    private static FunctionParameterR[] S = { FunctionParameterR.param(DataType.STRING, "Name") };
     //"fvS"
     
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/parameter/ParameterResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/parameter/ParameterResolver.java
@@ -45,29 +45,29 @@ public class ParameterResolver extends AbstractMetaDataMultiResolver {
     private static final List<String> RESERVED_WORDS = List.of("NUMERIC", "STRING");
     private static String DESCRIPTION = "Returns default value of parameter.";
 
-    private static FunctionParameterR[] SySS = { new FunctionParameterR(DataType.STRING, "Name"),
-            new FunctionParameterR(DataType.SYMBOL, "Type", Optional.of(RESERVED_WORDS)), new FunctionParameterR(DataType.STRING, "DefaultValue"),
-            new FunctionParameterR(DataType.STRING, "Description") };
-    private static FunctionParameterR[] SyS = { new FunctionParameterR(DataType.STRING, "Name"),
-            new FunctionParameterR(DataType.SYMBOL, "Type", Optional.of(RESERVED_WORDS)), new FunctionParameterR(DataType.STRING, "DefaultValue") };
+    private static FunctionParameterR[] SySS = { FunctionParameterR.param(DataType.STRING, "Name"),
+            new FunctionParameterR(DataType.SYMBOL, "Type", Optional.of(RESERVED_WORDS)), FunctionParameterR.param(DataType.STRING, "DefaultValue"),
+            FunctionParameterR.param(DataType.STRING, "Description") };
+    private static FunctionParameterR[] SyS = { FunctionParameterR.param(DataType.STRING, "Name"),
+            new FunctionParameterR(DataType.SYMBOL, "Type", Optional.of(RESERVED_WORDS)), FunctionParameterR.param(DataType.STRING, "DefaultValue") };
 
-    private static FunctionParameterR[] SynS = { new FunctionParameterR(DataType.STRING, "Name"),
-            new FunctionParameterR(DataType.SYMBOL, "Type", Optional.of(RESERVED_WORDS)), new FunctionParameterR(DataType.NUMERIC, "DefaultValue"),
-            new FunctionParameterR(DataType.STRING, "Description") };
-    private static FunctionParameterR[] Syn = { new FunctionParameterR(DataType.STRING, "Name"),
-            new FunctionParameterR(DataType.SYMBOL, "Type", Optional.of(RESERVED_WORDS)), new FunctionParameterR(DataType.NUMERIC, "DefaultValue") };
+    private static FunctionParameterR[] SynS = { FunctionParameterR.param(DataType.STRING, "Name"),
+            new FunctionParameterR(DataType.SYMBOL, "Type", Optional.of(RESERVED_WORDS)), FunctionParameterR.param(DataType.NUMERIC, "DefaultValue"),
+            FunctionParameterR.param(DataType.STRING, "Description") };
+    private static FunctionParameterR[] Syn = { FunctionParameterR.param(DataType.STRING, "Name"),
+            new FunctionParameterR(DataType.SYMBOL, "Type", Optional.of(RESERVED_WORDS)), FunctionParameterR.param(DataType.NUMERIC, "DefaultValue") };
 
-    private static FunctionParameterR[] ShmS = { new FunctionParameterR(DataType.STRING, "Name"),
-            new FunctionParameterR(DataType.HIERARCHY), new FunctionParameterR(DataType.MEMBER, "DefaultValue"),
-            new FunctionParameterR(DataType.STRING, "Description") };
-    private static FunctionParameterR[] Shm = { new FunctionParameterR(DataType.STRING, "Name"),
-            new FunctionParameterR(DataType.HIERARCHY), new FunctionParameterR(DataType.MEMBER, "DefaultValue") };
+    private static FunctionParameterR[] ShmS = { FunctionParameterR.param(DataType.STRING, "Name"),
+            FunctionParameterR.param(DataType.HIERARCHY), FunctionParameterR.param(DataType.MEMBER, "DefaultValue"),
+            FunctionParameterR.param(DataType.STRING, "Description") };
+    private static FunctionParameterR[] Shm = { FunctionParameterR.param(DataType.STRING, "Name"),
+            FunctionParameterR.param(DataType.HIERARCHY), FunctionParameterR.param(DataType.MEMBER, "DefaultValue") };
 
-    private static FunctionParameterR[] ShxS = { new FunctionParameterR(DataType.STRING, "Name"),
-            new FunctionParameterR(DataType.HIERARCHY), new FunctionParameterR(DataType.SET, "DefaultValue"),
-            new FunctionParameterR(DataType.STRING, "Description") };
-    private static FunctionParameterR[] Shx = { new FunctionParameterR(DataType.STRING, "Name"),
-            new FunctionParameterR(DataType.HIERARCHY), new FunctionParameterR(DataType.SET, "DefaultValue") };
+    private static FunctionParameterR[] ShxS = { FunctionParameterR.param(DataType.STRING, "Name"),
+            FunctionParameterR.param(DataType.HIERARCHY), FunctionParameterR.param(DataType.SET, "DefaultValue"),
+            FunctionParameterR.param(DataType.STRING, "Description") };
+    private static FunctionParameterR[] Shx = { FunctionParameterR.param(DataType.STRING, "Name"),
+            FunctionParameterR.param(DataType.HIERARCHY), FunctionParameterR.param(DataType.SET, "DefaultValue") };
 
     // {"fSSySS", "fSSyS", "fnSynS", "fnSyn", "fmShmS", "fmShm","fxShxS", "fxShx"}
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/percentile/PercentileResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/percentile/PercentileResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,12 +29,12 @@ import org.osgi.service.component.annotations.Component;
 public class PercentileResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Percentile");
     private static String DESCRIPTION = "Returns the value of the tuple that is at a given percentile of a set.";
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC), new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] xnn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC), FunctionParameterR.param(DataType.NUMERIC) };
     // {"fnxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xnn);
+            DataType.NUMERIC, xnn).interfaceName(FunctionInterface.STATISTICAL);
 
     public PercentileResolver() {
         super(List.of(new PercentileFunDef(functionMetaData)));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/PeriodsToDateResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/PeriodsToDateResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,20 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class PeriodsToDateResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("PeriodsToDate");
     private static String DESCRIPTION = "Returns a set of periods (members) from a specified level starting with the first period and ending with a specified member.";
-    private static FunctionParameterR[] p = { };
-    private static FunctionParameterR[] l = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] lm = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] lm = { FunctionParameterR.param(DataType.SET).asOptional(),
+            FunctionParameterR.param(DataType.NUMERIC).asOptional() };
     // {"fx", "fxl", "fxlm"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, p);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, l);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, lm);
+            DataType.SET, lm).interfaceName(FunctionInterface.DATETIME);
 
     public PeriodsToDateResolver() {
-        super(List.of(new PeriodsToDateFunDef(functionMetaData), new PeriodsToDateFunDef(functionMetaData1), new PeriodsToDateFunDef(functionMetaData2)));
+        super(List.of(new PeriodsToDateFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/MtdMultiResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/MtdMultiResolver.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAt
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.element.LevelType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -32,17 +33,12 @@ public class MtdMultiResolver extends AbstractFunctionDefinitionMultiResolver {
 
 	private static OperationAtom atom = new FunctionOperationAtom("Mtd");
 
-	private static FunctionMetaData functionMetaDataWithMember = new FunctionMetaDataR(atom,
+	private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom,
 			"A shortcut function for the PeriodsToDate function that specifies the level to be Month.",
-			DataType.SET, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
-
-	private static FunctionMetaData functionMetaDataWithoutMember = new FunctionMetaDataR(atom,
-			"A shortcut function for the PeriodsToDate function that specifies the level to be Month.",
-			DataType.SET, new FunctionParameterR[] { });
+			DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER).asOptional() }).interfaceName(FunctionInterface.DATETIME);
 
 	public MtdMultiResolver() {
-		super(List.of(new XtdFunDef(functionMetaDataWithMember, LevelType.TIME_MONTHS),
-				new XtdFunDef(functionMetaDataWithoutMember, LevelType.TIME_MONTHS)));
+		super(List.of(new XtdFunDef(functionMetaData, LevelType.TIME_MONTHS)));
 	}
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/QtdMultiResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/QtdMultiResolver.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAt
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.element.LevelType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,17 +32,12 @@ public class QtdMultiResolver extends AbstractFunctionDefinitionMultiResolver {
 
 	private static OperationAtom atom = new FunctionOperationAtom("Qtd");
 
-	private static FunctionMetaData functionMetaDataWithMember = new FunctionMetaDataR(atom,
+	private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom,
 			"A shortcut function for the PeriodsToDate function that specifies the level to be Quater.",
-			DataType.SET, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ) });
-
-	private static FunctionMetaData functionMetaDataWithoutMember = new FunctionMetaDataR(atom,
-			"A shortcut function for the PeriodsToDate function that specifies the level to be Quater.",
-			DataType.SET, new FunctionParameterR[] { });
+			DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER).asOptional() }).interfaceName(FunctionInterface.DATETIME);
 
 	public QtdMultiResolver() {
-		super(List.of(new XtdFunDef(functionMetaDataWithMember, LevelType.TIME_QUARTERS),
-				new XtdFunDef(functionMetaDataWithoutMember, LevelType.TIME_QUARTERS)));
+		super(List.of(new XtdFunDef(functionMetaData, LevelType.TIME_QUARTERS)));
 	}
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/WtdMultiResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/WtdMultiResolver.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAt
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.element.LevelType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,17 +32,12 @@ public class WtdMultiResolver extends AbstractFunctionDefinitionMultiResolver {
 
 	private static OperationAtom atom = new FunctionOperationAtom("Wtd");
 
-	private static FunctionMetaData functionMetaDataWithMember = new FunctionMetaDataR(atom,
+	private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom,
 			"A shortcut function for the PeriodsToDate function that specifies the level to be Week.",
-			DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
-
-	private static FunctionMetaData functionMetaDataWithoutMember = new FunctionMetaDataR(atom,
-			"A shortcut function for the PeriodsToDate function that specifies the level to be Week.",
-			DataType.SET, new FunctionParameterR[] { });
+			DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER).asOptional() }).interfaceName(FunctionInterface.DATETIME);
 
 	public WtdMultiResolver() {
-		super(List.of(new XtdFunDef(functionMetaDataWithMember, LevelType.TIME_WEEKS),
-				new XtdFunDef(functionMetaDataWithoutMember, LevelType.TIME_WEEKS)));
+		super(List.of(new XtdFunDef(functionMetaData, LevelType.TIME_WEEKS)));
 	}
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/YtdMultiResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/YtdMultiResolver.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAt
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.element.LevelType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,16 +32,12 @@ public class YtdMultiResolver extends AbstractFunctionDefinitionMultiResolver {
 
 	private static OperationAtom atom = new FunctionOperationAtom("Ytd");
 
-	private static FunctionMetaData functionMetaDataWithMember = new FunctionMetaDataR(atom,
+	private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom,
 			"A shortcut function for the PeriodsToDate function that specifies the level to be Year.",
-			DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
-
-	private static FunctionMetaData functionMetaDataWithoutMember = new FunctionMetaDataR(atom,
-			"A shortcut function for the PeriodsToDate function that specifies the level to be Year.",
-			DataType.SET, new FunctionParameterR[] {  });
+			DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER).asOptional() }).interfaceName(FunctionInterface.DATETIME);
 
 	public YtdMultiResolver() {
-		super(List.of(new XtdFunDef(functionMetaDataWithMember, LevelType.TIME_YEARS),new XtdFunDef(functionMetaDataWithoutMember, LevelType.TIME_YEARS)));
+		super(List.of(new XtdFunDef(functionMetaData, LevelType.TIME_YEARS)));
 	}
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/properties/PropertiesFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/properties/PropertiesFunDef.java
@@ -27,8 +27,8 @@ import org.eclipse.daanse.olap.function.def.AbstractFunctionDefinition;
 
 public class PropertiesFunDef extends AbstractFunctionDefinition {
     static OperationAtom functionAtom = new MethodOperationAtom("Properties");
-    public static final FunctionParameterR[] PARAMETER_TYPES = { new FunctionParameterR(DataType.MEMBER),
-            new FunctionParameterR(DataType.STRING, "String") };
+    public static final FunctionParameterR[] PARAMETER_TYPES = { FunctionParameterR.param(DataType.MEMBER),
+            FunctionParameterR.param(DataType.STRING, "String") };
 
     public PropertiesFunDef(DataType returnType) {
         super(new FunctionMetaDataR(functionAtom, "Returns the value of a member property.",

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/properties/PropertiesResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/properties/PropertiesResolver.java
@@ -13,20 +13,27 @@
  */
 package org.eclipse.daanse.olap.function.def.properties;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.element.Hierarchy;
 import org.eclipse.daanse.olap.api.element.Level;
 import org.eclipse.daanse.olap.api.element.Property;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.query.component.Literal;
 import org.eclipse.daanse.olap.common.Util;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -56,19 +63,19 @@ public class PropertiesResolver  implements FunctionResolver {
         }
 
         @Override
-        public FunctionDefinition resolve(
+        public Optional<FunctionResolutionResult> resolve(
             Expression[] args,
-            Validator validator,
-            List<Conversion> conversions)
+            Validator validator)
         {
+            List<Conversion> conversions = new ArrayList<>();
             if (!matches(args, PropertiesFunDef.PARAMETER_TYPES, validator, conversions)) {
-                return null;
+                return Optional.empty();
             }
             DataType returnType = deducePropertyCategory(args[0], args[1]);
 
 
-            return new PropertiesFunDef(
-                returnType);
+            return Optional.of(FunctionResolutionResultR.of(new PropertiesFunDef(
+                returnType), conversions));
         }
 
         /**
@@ -127,6 +134,17 @@ public class PropertiesResolver  implements FunctionResolver {
         @Override
         public OperationAtom getFunctionAtom() {
             return PropertiesFunDef.functionAtom;
+        }
+
+        private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+            FunctionMetaDataR.of(PropertiesFunDef.functionAtom, "Returns the value of a member property.",
+                DataType.VALUE,
+                param(DataType.MEMBER),
+                param(DataType.STRING, "Property_Name")));
+
+        @Override
+        public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+            return REPRESENTATIVE_METADATAS;
         }
 
     }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/RankResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/rank/RankResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,24 +29,24 @@ import org.osgi.service.component.annotations.Component;
 public class RankResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Rank");
     private static String DESCRIPTION = "Returns the one-based rank of a tuple in a set.";
-    private static FunctionParameterR[] tx = { new FunctionParameterR(DataType.TUPLE), new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] txn = { new FunctionParameterR(DataType.TUPLE), new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
-    private static FunctionParameterR[] mx = { new FunctionParameterR(DataType.MEMBER), new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] mxn = { new FunctionParameterR(DataType.MEMBER), new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] tx = { FunctionParameterR.param(DataType.TUPLE), FunctionParameterR.param(DataType.SET) };
+    private static FunctionParameterR[] txn = { FunctionParameterR.param(DataType.TUPLE), FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC) };
+    private static FunctionParameterR[] mx = { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.SET) };
+    private static FunctionParameterR[] mxn = { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC) };
 
     // {"fitx", "fitxn", "fimx", "fimxn"}
 
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, tx);
+            DataType.INTEGER, tx).interfaceName(FunctionInterface.STATISTICAL);
     private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, txn);
+            DataType.INTEGER, txn).interfaceName(FunctionInterface.STATISTICAL);
     private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, mx);
+            DataType.INTEGER, mx).interfaceName(FunctionInterface.STATISTICAL);
     private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, mxn);
+            DataType.INTEGER, mxn).interfaceName(FunctionInterface.STATISTICAL);
 
     public RankResolver() {
         super(List.of(new RankFunDef(functionMetaData), new RankFunDef(functionMetaData1), new RankFunDef(functionMetaData2), new RankFunDef(functionMetaData3)));

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/SetResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/SetResolver.java
@@ -13,15 +13,22 @@
  */
 package org.eclipse.daanse.olap.function.def.set;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.osgi.service.component.annotations.Component;
 
@@ -29,39 +36,48 @@ import org.osgi.service.component.annotations.Component;
 public class SetResolver  extends NoExpressionRequiredFunctionResolver {
 
     @Override
-    public FunctionDefinition resolve(
+    public Optional<FunctionResolutionResult> resolve(
         Expression[] args,
-        Validator validator,
-        List<Conversion> conversions)
+        Validator validator)
     {
+        List<Conversion> conversions = new ArrayList<>();
         FunctionParameterR[] parameterTypes = new FunctionParameterR[args.length];
         for (int i = 0; i < args.length; i++) {
             if (validator.canConvert(
                     i, args[i], DataType.MEMBER, conversions))
             {
-                parameterTypes[i] = new FunctionParameterR(DataType.MEMBER);
+                parameterTypes[i] = FunctionParameterR.param(DataType.MEMBER);
                 continue;
             }
             if (validator.canConvert(
                     i, args[i], DataType.TUPLE, conversions))
             {
-                parameterTypes[i] = new FunctionParameterR(DataType.TUPLE);
+                parameterTypes[i] = FunctionParameterR.param(DataType.TUPLE);
                 continue;
             }
             if (validator.canConvert(
                     i, args[i], DataType.SET, conversions))
             {
-                parameterTypes[i] = new FunctionParameterR(DataType.SET);
+                parameterTypes[i] = FunctionParameterR.param(DataType.SET);
                 continue;
             }
-            return null;
+            return Optional.empty();
         }
 
-        return new SetFunDef(parameterTypes);
+        return Optional.of(FunctionResolutionResultR.of(new SetFunDef(parameterTypes), conversions));
     }
 
     @Override
     public OperationAtom getFunctionAtom() {
         return SetFunDef.functionAtom;
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+        FunctionMetaDataR.of(SetFunDef.functionAtom, SetFunDef.DESCRIPTION, DataType.SET,
+            param(DataType.VALUE, "Member_or_Set").asOptional().repeatable(1)));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/addcalculatedmembers/AddCalculatedMembersFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/addcalculatedmembers/AddCalculatedMembersFunDef.java
@@ -30,7 +30,7 @@ public class AddCalculatedMembersFunDef extends AbstractFunctionDefinition {
     static OperationAtom functionAtom = new FunctionOperationAtom("AddCalculatedMembers");
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom, "Adds calculated members to a set.",
-            DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.SET ) });
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) });
 
     public AddCalculatedMembersFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/ascendants/AscendantsFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/ascendants/AscendantsFunDef.java
@@ -30,7 +30,7 @@ public class AscendantsFunDef extends AbstractFunctionDefinition {
     static FunctionOperationAtom functionAtom = new FunctionOperationAtom("Ascendants");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Returns the set of the ascendants of a specified member.", DataType.SET,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) });
 
     public AscendantsFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/children/ChildrenFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/children/ChildrenFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class ChildrenFunDef extends AbstractFunctionDefinition {
     // <Member>.Children
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Children");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
-            "Returns the children of a member.", DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            "Returns the children of a member.", DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.NAVIGATION);
 
     public ChildrenFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/distinct/DistinctFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/distinct/DistinctFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -31,7 +32,7 @@ public class DistinctFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Eliminates duplicate tuples from a set.", DataType.SET,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.SET ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) }).interfaceName(FunctionInterface.FILTER);
 
     public DistinctFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/existing/ExistingFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/existing/ExistingFunDef.java
@@ -20,6 +20,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleIteratorCalc;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
@@ -35,7 +36,7 @@ public class ExistingFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Forces the set to be evaluated within the current context.", DataType.SET,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.SET ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) }).interfaceName(FunctionInterface.FILTER);
 
     protected ExistingFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/extract/ExtractFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/extract/ExtractFunDef.java
@@ -24,6 +24,7 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
 import org.eclipse.daanse.olap.api.element.Hierarchy;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.DimensionExpression;
 import org.eclipse.daanse.olap.api.query.component.Expression;
@@ -47,7 +48,7 @@ public class ExtractFunDef extends AbstractFunctionDefinition {
     public ExtractFunDef(FunctionParameterR[] parameterTypes) {
         super(new FunctionMetaDataR(functionAtom,
                 "Returns a set of tuples from extracted hierarchy elements. The opposite of Crossjoin.",
-                DataType.SET, parameterTypes));
+                DataType.SET, parameterTypes).interfaceName(FunctionInterface.FILTER));
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/extract/ExtractResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/extract/ExtractResolver.java
@@ -13,31 +13,39 @@
  */
 package org.eclipse.daanse.olap.function.def.set.extract;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.element.Hierarchy;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 
 public class ExtractResolver extends NoExpressionRequiredFunctionResolver {
     @Override
-    public FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions) {
+    public Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator) {
+        List<Conversion> conversions = new ArrayList<>();
         if (args.length < 2) {
-            return null;
+            return Optional.empty();
         }
         if (!validator.canConvert(0, args[0], DataType.SET, conversions)) {
-            return null;
+            return Optional.empty();
         }
         for (int i = 1; i < args.length; ++i) {
             if (!validator.canConvert(0, args[i], DataType.HIERARCHY, conversions)) {
-                return null;
+                return Optional.empty();
             }
         }
 
@@ -55,15 +63,26 @@ public class ExtractResolver extends NoExpressionRequiredFunctionResolver {
         final List<Hierarchy> extractedHierarchies = new ArrayList<>();
         ExtractFunDef.findExtractedHierarchies(args, extractedHierarchies, extractedOrdinals);
         FunctionParameterR[] parameterTypes = new FunctionParameterR[args.length];
-        parameterTypes[0] = new FunctionParameterR(DataType.SET);
-        Arrays.fill(parameterTypes, 1, parameterTypes.length, new FunctionParameterR(DataType.HIERARCHY));
+        parameterTypes[0] = FunctionParameterR.param(DataType.SET);
+        Arrays.fill(parameterTypes, 1, parameterTypes.length, FunctionParameterR.param(DataType.HIERARCHY));
 
-        return new ExtractFunDef(parameterTypes);
+        return Optional.of(FunctionResolutionResultR.of(new ExtractFunDef(parameterTypes), conversions));
     }
 
     @Override
     public OperationAtom getFunctionAtom() {
         return ExtractFunDef.functionAtom;
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+        FunctionMetaDataR.of(ExtractFunDef.functionAtom,
+            "Returns a set of tuples from extracted hierarchy elements. The opposite of Crossjoin.", DataType.SET,
+            param(DataType.SET),
+            param(DataType.HIERARCHY, "Hierarchy").repeatable(1)).interfaceName(FunctionInterface.FILTER));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/filter/FilterFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/filter/FilterFunDef.java
@@ -24,6 +24,7 @@ import org.eclipse.daanse.olap.api.calc.ResultStyle;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleIteratorCalc;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.exceptions.ResultStyleException;
@@ -40,7 +41,7 @@ public class FilterFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Returns the set resulting from filtering a set based on a search condition.",
-            DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.SET ), new FunctionParameterR( DataType.LOGICAL ) });
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.LOGICAL) }).interfaceName(FunctionInterface.FILTER);
 
     public FilterFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/hierarchy/AllMembersFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/hierarchy/AllMembersFunDef.java
@@ -29,7 +29,7 @@ public class AllMembersFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("AllMembers");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns a set that contains all members, including calculated members, of the specified hierarchy.",
-            DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.HIERARCHY ) });
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) });
 
     public AllMembersFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/level/AllMembersFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/level/AllMembersFunDef.java
@@ -30,7 +30,7 @@ public class AllMembersFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("AllMembers");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns a set that contains all members, including calculated members, of the specified level.",
-            DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.LEVEL ) });
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) });
 
     public AllMembersFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/level/LevelMembersFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/level/LevelMembersFunDef.java
@@ -32,7 +32,7 @@ public class LevelMembersFunDef extends AbstractFunctionDefinition {
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the set of members in a level.", DataType.SET,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.LEVEL ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) });
 
     public static final LevelMembersFunDef INSTANCE = new LevelMembersFunDef();
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/members/MembersFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/members/MembersFunDef.java
@@ -30,7 +30,7 @@ public class MembersFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Members");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the set of members in a hierarchy.", DataType.SET,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.HIERARCHY ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) });
 
     public MembersFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/range/RangeFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/range/RangeFunDef.java
@@ -36,7 +36,7 @@ public class RangeFunDef extends AbstractFunctionDefinition {
     static final RangeFunDef instance = new RangeFunDef();
     static final FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Infix colon operator returns the set of members between a given pair of members.",
-            DataType.SET, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER, "Member1" ), new FunctionParameterR( DataType.MEMBER, "Member2" ) });
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER, "Member1"), FunctionParameterR.param(DataType.MEMBER, "Member2") });
     private final static String twoNullsNotSupported = "Function does not support two NULL member parameters";
 
     public RangeFunDef() {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/setitem/SetItemIntResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/setitem/SetItemIntResolver.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
 public class SetItemIntResolver extends AbstractFunctionDefinitionMultiResolver {
     private static MethodOperationAtom atom = new MethodOperationAtom("Item");
     private static String DESCRIPTION = "Returns a tuple from the set specified in <Set>. The tuple to be returned is specified by the zero-based position of the tuple in the set in <Index>.";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.NUMERIC, "Index") };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.NUMERIC, "Index") };
     // {"mmxn"}
 
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/setitem/SetItemStringResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/setitem/SetItemStringResolver.java
@@ -13,18 +13,23 @@
  */
 package org.eclipse.daanse.olap.function.def.set.setitem;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.type.SetType;
 import org.eclipse.daanse.olap.common.Util;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.eclipse.daanse.olap.query.base.Expressions;
 import org.osgi.service.component.annotations.Component;
@@ -32,20 +37,21 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = FunctionResolver.class)
 public class SetItemStringResolver extends NoExpressionRequiredFunctionResolver {
     @Override
-    public FunctionDefinition resolve(Expression[] args, Validator validator, List<Conversion> conversions) {
+    public Optional<FunctionResolutionResult> resolve(Expression[] args, Validator validator) {
+        List<Conversion> conversions = new ArrayList<>();
         if (args.length < 1) {
-            return null;
+            return Optional.empty();
         }
         final Expression setExp = args[0];
         if (!(setExp.getType() instanceof SetType)) {
-            return null;
+            return Optional.empty();
         }
         final SetType setType = (SetType) setExp.getType();
         final int arity = setType.getArity();
         // All args must be strings.
         for (int i = 1; i < args.length; i++) {
             if (!validator.canConvert(i, args[i], DataType.STRING, conversions)) {
-                return null;
+                return Optional.empty();
             }
         }
         if (args.length - 1 != arity) {
@@ -57,12 +63,24 @@ public class SetItemStringResolver extends NoExpressionRequiredFunctionResolver 
                 "Returns a tuple from the set specified in <Set>. The tuple to be returned is specified by the member name (or names) in <String>.",
                 category, Expressions.functionParameterOf(args));
 
-        return new SetItemFunDef(functionMetaData);
+        return Optional.of(FunctionResolutionResultR.of(new SetItemFunDef(functionMetaData), conversions));
     }
 
     @Override
     public OperationAtom getFunctionAtom() {
         return SetItemFunDef.functionAtom;
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+            FunctionMetaDataR.of(SetItemFunDef.functionAtom,
+                    "Returns a tuple from the set specified in <Set>. The tuple to be returned is specified by the member name (or names) in <String>.",
+                    DataType.TUPLE,
+                    param(DataType.SET),
+                    param(DataType.STRING, "Member_Name").repeatable(1)));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/siblings/SiblingsFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/siblings/SiblingsFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class SiblingsFunDef extends AbstractFunctionDefinition {
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Siblings");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom,
             "Returns the siblings of a specified member, including the member itself.",
-            DataType.SET, new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER )});
+            DataType.SET, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER)}).interfaceName(FunctionInterface.NAVIGATION);
 
     public SiblingsFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/set/stripcalculatedmembers/StripCalculatedMembersFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/set/stripcalculatedmembers/StripCalculatedMembersFunDef.java
@@ -30,7 +30,7 @@ public class StripCalculatedMembersFunDef extends AbstractFunctionDefinition {
     static FunctionOperationAtom functionAtom = new FunctionOperationAtom("StripCalculatedMembers");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom,
             "Removes calculated members from a set.", DataType.SET,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.SET ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) });
 
     public StripCalculatedMembersFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/settostr/SetToStrFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/settostr/SetToStrFunDef.java
@@ -31,7 +31,7 @@ public class SetToStrFunDef extends AbstractFunctionDefinition {
     static OperationAtom functionAtom = new FunctionOperationAtom("SetToStr");
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom, "Constructs a string from a set.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.SET ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.SET) });
 
     public static final AbstractFunctionDefinition instance = new SetToStrFunDef();
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/stdev/StddevPResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/stdev/StddevPResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class StddevPResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("StddevP");
     private static String DESCRIPTION = "Alias for StdevP.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC).asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public StddevPResolver() {
-        super(List.of(new StdevPFunDef(functionMetaData), new StdevPFunDef(functionMetaData1)));
+        super(List.of(new StdevPFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/stdev/StddevResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/stdev/StddevResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class StddevResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Stddev");
     private static String DESCRIPTION = "Alias for Stdev.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC).asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public StddevResolver() {
-        super(List.of(new StdevFunDef(functionMetaData), new StdevFunDef(functionMetaData1)));
+        super(List.of(new StdevFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/stdev/StdevPResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/stdev/StdevPResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class StdevPResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("StdevP");
     private static String DESCRIPTION = "Returns the standard deviation of a numeric expression evaluated over a set (biased).";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC).asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public StdevPResolver() {
-        super(List.of(new StdevPFunDef(functionMetaData), new StdevPFunDef(functionMetaData1)));
+        super(List.of(new StdevPFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/stdev/StdevResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/stdev/StdevResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class StdevResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Stdev");
     private static String DESCRIPTION = "Returns the standard deviation of a numeric expression evaluated over a set (unbiased).";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC).asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public StdevResolver() {
-        super(List.of(new StdevFunDef(functionMetaData), new StdevFunDef(functionMetaData1)));
+        super(List.of(new StdevFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/string/LenFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/string/LenFunDef.java
@@ -30,7 +30,7 @@ public class LenFunDef extends AbstractFunctionDefinition {
     static FunctionOperationAtom functionOperationAtom = new FunctionOperationAtom("Len");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionOperationAtom,
             "Returns the number of characters in a string", DataType.NUMERIC,
-            new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "String" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String") });
 
     public LenFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/string/UCaseFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/string/UCaseFunDef.java
@@ -34,7 +34,7 @@ public class UCaseFunDef extends AbstractFunctionDefinition {
     static FunctionOperationAtom functionOperationAtom = new FunctionOperationAtom("UCase");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionOperationAtom,
             "Returns a string that has been converted to uppercase", DataType.STRING,
-            new FunctionParameterR[] { new FunctionParameterR(  DataType.STRING, "String" ) });
+            new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String") });
 
     public UCaseFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/strtoset/StrToSetResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/strtoset/StrToSetResolver.java
@@ -14,11 +14,12 @@
 package org.eclipse.daanse.olap.function.def.strtoset;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.DimensionExpression;
@@ -28,6 +29,7 @@ import org.eclipse.daanse.olap.api.type.StringType;
 import org.eclipse.daanse.olap.api.type.Type;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.eclipse.daanse.olap.query.component.HierarchyExpressionImpl;
 import org.osgi.service.component.annotations.Component;
@@ -36,36 +38,35 @@ import org.osgi.service.component.annotations.Component;
 public class StrToSetResolver extends NoExpressionRequiredFunctionResolver {
 
     @Override
-    public FunctionDefinition resolve(
+    public Optional<FunctionResolutionResult> resolve(
         Expression[] args,
-        Validator validator,
-        List<Conversion> conversions)
+        Validator validator)
     {
         if (args.length < 1) {
-            return null;
+            return Optional.empty();
         }
         Type type = args[0].getType();
         if (!(type instanceof StringType)
             && !(type instanceof NullType))
         {
-            return null;
+            return Optional.empty();
         }
         for (int i = 1; i < args.length; i++) {
             Expression exp = args[i];
             if (!(exp instanceof DimensionExpression
                   || exp instanceof HierarchyExpressionImpl))
             {
-                return null;
+                return Optional.empty();
             }
         }
         FunctionParameterR[] argTypes = new FunctionParameterR[args.length];
-        argTypes[0] = new FunctionParameterR( DataType.STRING );
+        argTypes[0] = FunctionParameterR.param(DataType.STRING);
         for (int i = 1; i < argTypes.length; i++) {
-            argTypes[i] = new FunctionParameterR( DataType.HIERARCHY );
+            argTypes[i] = FunctionParameterR.param(DataType.HIERARCHY);
         }
 
         FunctionMetaData functionMetaData = functionMetaDataFor(argTypes);
-        return new StrToSetFunDef(functionMetaData);
+        return Optional.of(FunctionResolutionResultR.of(new StrToSetFunDef(functionMetaData), List.<Conversion>of()));
     }
 
 
@@ -79,7 +80,7 @@ public class StrToSetResolver extends NoExpressionRequiredFunctionResolver {
 
     @Override
     public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
-        return List.of(functionMetaDataFor(new FunctionParameterR[] { new FunctionParameterR( DataType.STRING ) }));
+        return List.of(functionMetaDataFor(new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING) }));
     }
 
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/strtotuple/StrToTupleResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/strtotuple/StrToTupleResolver.java
@@ -14,11 +14,12 @@
 package org.eclipse.daanse.olap.function.def.strtotuple;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.DimensionExpression;
@@ -28,6 +29,7 @@ import org.eclipse.daanse.olap.api.type.StringType;
 import org.eclipse.daanse.olap.api.type.Type;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.eclipse.daanse.olap.query.component.HierarchyExpressionImpl;
 import org.osgi.service.component.annotations.Component;
@@ -37,40 +39,39 @@ public class StrToTupleResolver extends NoExpressionRequiredFunctionResolver {
 
 
     @Override
-    public FunctionDefinition resolve(
+    public Optional<FunctionResolutionResult> resolve(
         Expression[] args,
-        Validator validator,
-        List<Conversion> conversions)
+        Validator validator)
     {
         if (args.length < 1) {
-            return null;
+            return Optional.empty();
         }
         Type type = args[0].getType();
         if (!(type instanceof StringType)
             && !(type instanceof NullType))
         {
-            return null;
+            return Optional.empty();
         }
         for (int i = 1; i < args.length; i++) {
             Expression exp = args[i];
             if (!(exp instanceof DimensionExpression
                 || exp instanceof HierarchyExpressionImpl))
             {
-                return null;
+                return Optional.empty();
             }
         }
         FunctionParameterR[] argTypes = new FunctionParameterR[args.length];
-        argTypes[0] = new FunctionParameterR(DataType.STRING);
+        argTypes[0] = FunctionParameterR.param(DataType.STRING);
         for (int i = 1; i < argTypes.length; i++) {
-            argTypes[i] = new FunctionParameterR(DataType.HIERARCHY);
+            argTypes[i] = FunctionParameterR.param(DataType.HIERARCHY);
         }
-        return new StrToTupleFunDef(functionMetaDataFor(argTypes));
+        return Optional.of(FunctionResolutionResultR.of(new StrToTupleFunDef(functionMetaDataFor(argTypes)), List.<Conversion>of()));
     }
 
 
     @Override
     public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
-        return List.of( functionMetaDataFor(new FunctionParameterR[] {new FunctionParameterR(DataType.STRING)}));
+        return List.of( functionMetaDataFor(new FunctionParameterR[] {FunctionParameterR.param(DataType.STRING)}));
     }
 
     private FunctionMetaData functionMetaDataFor(FunctionParameterR[] argTypes) {

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/subset/SubsetResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/subset/SubsetResolver.java
@@ -28,17 +28,17 @@ import org.osgi.service.component.annotations.Component;
 public class SubsetResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Subset");
     private static String DESCRIPTION = "Returns a subset of elements from a set.";
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.NUMERIC, "Start") };
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Start"), new FunctionParameterR(DataType.NUMERIC, "Count") };
+    private static FunctionParameterR[] xnn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Start")
+                    .describedAs("Zero-based position of the first member to return."),
+            FunctionParameterR.param(DataType.NUMERIC, "Count")
+                    .describedAs("Number of members to return; omitted = to the end of the set.").asOptional() };
     // {"fxxn", "fxxnn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
             DataType.SET, xnn);
 
     public SubsetResolver() {
-        super(List.of(new SubsetFunDef(functionMetaData), new SubsetFunDef(functionMetaData1)));
+        super(List.of(new SubsetFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/sum/SumResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/sum/SumResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class SumResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Sum");
     private static String DESCRIPTION = "Returns the sum of a numeric expression evaluated over a set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC).asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public SumResolver() {
-        super(List.of(new SumFunDef(functionMetaData), new SumFunDef(functionMetaData1)));
+        super(List.of(new SumFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/toggledrillstate/ToggleDrillStateResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/toggledrillstate/ToggleDrillStateResolver.java
@@ -30,19 +30,18 @@ public class ToggleDrillStateResolver extends AbstractFunctionDefinitionMultiRes
     private static FunctionOperationAtom atom = new FunctionOperationAtom("ToggleDrillState");
     static final List<String> ReservedWords = List.of("RECURSIVE");
     private static String DESCRIPTION = "Toggles the drill state of members. This function is a combination of DrillupMember and DrilldownMember.";
-    private static FunctionParameterR[] xx = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2") };
-    private static FunctionParameterR[] xxy = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2"), new FunctionParameterR(DataType.SYMBOL, "RECURSIVE", Optional.of(ReservedWords)) };
+    private static FunctionParameterR[] xxy = { FunctionParameterR.param(DataType.SET, "Set1"),
+            FunctionParameterR.param(DataType.SET, "Set2"),
+            new FunctionParameterR(DataType.SYMBOL, "RECURSIVE", Optional.of(ReservedWords))
+                    .describedAs("RECURSIVE toggles the drill state of every descendant of the members in the second set.")
+                    .asOptional() };
     // {"fxxx", "fxxxy"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION, DataType.SET,
-            xx);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xxy);
+            xxy);
 
     public ToggleDrillStateResolver() {
-        super(List.of(new ToggleDrillStateFunDef(functionMetaData), new ToggleDrillStateFunDef(functionMetaData1)));
+        super(List.of(new ToggleDrillStateFunDef(functionMetaData)));
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottomcount/BottomCountResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottomcount/BottomCountResolver.java
@@ -28,19 +28,17 @@ import org.osgi.service.component.annotations.Component;
 public class BottomCountResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("BottomCount");
     private static String DESCRIPTION = "Returns a specified number of items from the bottom of a set, optionally ordering the set first.";
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count"), new FunctionParameterR(DataType.NUMERIC) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count") };
+    private static FunctionParameterR[] xnn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count"),
+            FunctionParameterR.param(DataType.NUMERIC)
+                    .describedAs("Expression that ranks the members; without it the members keep their natural order.")
+                    .asOptional() };
     // {"fxxnn", "fxxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION, DataType.SET,
             xnn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xn);
 
     public BottomCountResolver() {
-        super(List.of(new TopBottomCountFunDef(functionMetaData, false),
-                new TopBottomCountFunDef(functionMetaData1, false)));
+        super(List.of(new TopBottomCountFunDef(functionMetaData, false)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottomcount/TopCountResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottomcount/TopCountResolver.java
@@ -28,19 +28,17 @@ import org.osgi.service.component.annotations.Component;
 public class TopCountResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("TopCount");
     private static String DESCRIPTION = "Returns a specified number of items from the top of a set, optionally ordering the set first.";
-    private static FunctionParameterR[] xnn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count"), new FunctionParameterR(DataType.NUMERIC) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Count") };
+    private static FunctionParameterR[] xnn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Count"),
+            FunctionParameterR.param(DataType.NUMERIC)
+                    .describedAs("Expression that ranks the members; without it the members keep their natural order.")
+                    .asOptional() };
     // {"fxxnn", "fxxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION, DataType.SET,
             xnn);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xn);
 
     public TopCountResolver() {
-        super(List.of(new TopBottomCountFunDef(functionMetaData, true),
-                new TopBottomCountFunDef(functionMetaData1, true)));
+        super(List.of(new TopBottomCountFunDef(functionMetaData, true)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/BottomPercentResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/BottomPercentResolver.java
@@ -28,8 +28,8 @@ public class BottomPercentResolver extends ParametersCheckingFunctionDefinitionR
 
     static final OperationAtom atomBottomPercent = new FunctionOperationAtom("BottomPercent");
     private static String DESCRIPTION = "Sorts a set and returns the bottom N elements whose cumulative total is at least a specified percentage.";
-    private static FunctionParameterR[] params = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Percentage"), new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Percentage"), FunctionParameterR.param(DataType.NUMERIC) };
 
     static final FunctionMetaData fmdBottomPercent = new FunctionMetaDataR(atomBottomPercent, DESCRIPTION,
             DataType.SET, params);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/BottomSumResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/BottomSumResolver.java
@@ -28,8 +28,8 @@ public class BottomSumResolver extends ParametersCheckingFunctionDefinitionResol
 
     static final OperationAtom atomBottomSum = new FunctionOperationAtom("BottomSum");
     private static String DESCRIPTION = "Sorts a set and returns the bottom N elements whose cumulative total is at least a specified value.";
-    private static FunctionParameterR[] params = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Value"), new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Value"), FunctionParameterR.param(DataType.NUMERIC) };
 
     static final FunctionMetaData fmdBottomSum = new FunctionMetaDataR(atomBottomSum, DESCRIPTION,
             DataType.SET, params);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/TopPercentResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/TopPercentResolver.java
@@ -28,8 +28,8 @@ public class TopPercentResolver extends ParametersCheckingFunctionDefinitionReso
 
     static final OperationAtom atomTopPercent = new FunctionOperationAtom("TopPercent");
     private static String DESCRIPTION = "Sorts a set and returns the top N elements whose cumulative total is at least a specified percentage.";
-    private static FunctionParameterR[] params = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Percentage"), new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Percentage"), FunctionParameterR.param(DataType.NUMERIC) };
 
     static final FunctionMetaData fmdTopPercent = new FunctionMetaDataR(atomTopPercent, DESCRIPTION,
             DataType.SET, params);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/TopSumResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/TopSumResolver.java
@@ -28,8 +28,8 @@ public class TopSumResolver extends ParametersCheckingFunctionDefinitionResolver
 
     static final OperationAtom atomTopSum = new FunctionOperationAtom("TopSum");
     private static String DESCRIPTION = "Sorts a set and returns the top N elements whose cumulative total is at least a specified value.";
-    private static FunctionParameterR[] params = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Value"), new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Value"), FunctionParameterR.param(DataType.NUMERIC) };
 
     static final FunctionMetaData fmdTopSum = new FunctionMetaDataR(atomTopSum, DESCRIPTION,
             DataType.SET, params);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/tuple/TupleResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/tuple/TupleResolver.java
@@ -13,18 +13,23 @@
  */
 package org.eclipse.daanse.olap.function.def.tuple;
 
+import static org.eclipse.daanse.olap.function.core.FunctionParameterR.param;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.type.MemberType;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.resolver.FunctionResolutionResultR;
 import org.eclipse.daanse.olap.function.core.resolver.NoExpressionRequiredFunctionResolver;
 import org.eclipse.daanse.olap.function.def.crossjoin.CrossJoinFunDef;
 import org.eclipse.daanse.olap.function.def.parentheses.ParenthesesFunDef;
@@ -39,11 +44,11 @@ public class TupleResolver extends NoExpressionRequiredFunctionResolver {
         return TupleFunDef.functionAtom;
     }
     @Override
-    public FunctionDefinition resolve(
+    public Optional<FunctionResolutionResult> resolve(
         Expression[] args,
-        Validator validator,
-        List<Conversion> conversions)
+        Validator validator)
     {
+        List<Conversion> conversions = new ArrayList<>();
         // Compare with TupleFunDef.getReturnCategory().  For example,
         //   ([Gender].members) is a set,
         //   ([Gender].[M]) is a member,
@@ -51,7 +56,7 @@ public class TupleResolver extends NoExpressionRequiredFunctionResolver {
         // but
         //   ([Gender].[M], [Marital Status].[S]) is a tuple.
         if (args.length == 1 && !(args[0].getType() instanceof MemberType)) {
-            return new ParenthesesFunDef(args[0].getCategory());
+            return Optional.of(FunctionResolutionResultR.of(new ParenthesesFunDef(args[0].getCategory()), conversions));
         } else {
             final FunctionParameterR[] argTypes = new FunctionParameterR[args.length];
             boolean hasSet = false;
@@ -63,14 +68,14 @@ public class TupleResolver extends NoExpressionRequiredFunctionResolver {
                 //  ([Gender].[S], [Store].[Store City]) (member, level)
                 if (validator.canConvert(
                         i, args[i], DataType.MEMBER, conversions)) {
-                    argTypes[i] = new FunctionParameterR(DataType.MEMBER);
+                    argTypes[i] = FunctionParameterR.param(DataType.MEMBER);
                 } else if(validator.canConvert(
                         i, args[i], DataType.SET, conversions)){
                     hasSet = true;
-                    argTypes[i] = new FunctionParameterR(DataType.SET);
+                    argTypes[i] = FunctionParameterR.param(DataType.SET);
                 }
                 else {
-                    return null;
+                    return Optional.empty();
                 }
             }
             if(hasSet){
@@ -79,7 +84,7 @@ public class TupleResolver extends NoExpressionRequiredFunctionResolver {
                           DataType.SET, Expressions.functionParameterOf(args));
 
 
-                return new CrossJoinFunDef(functionMetaData);
+                return Optional.of(FunctionResolutionResultR.of(new CrossJoinFunDef(functionMetaData), conversions));
             }
             else {
 
@@ -87,8 +92,19 @@ public class TupleResolver extends NoExpressionRequiredFunctionResolver {
                 FunctionMetaData functionMetaData = new FunctionMetaDataR(TupleFunDef.functionAtom,"Parenthesis operator constructs a tuple.  If there is only one member, the expression is equivalent to the member expression.",
                           DataType.TUPLE, argTypes);
 
-                return new TupleFunDef(functionMetaData);
+                return Optional.of(FunctionResolutionResultR.of(new TupleFunDef(functionMetaData), conversions));
             }
         }
+    }
+
+    private static final List<FunctionMetaData> REPRESENTATIVE_METADATAS = List.<FunctionMetaData>of(
+        FunctionMetaDataR.of(TupleFunDef.functionAtom,
+            "Parenthesis operator constructs a tuple.  If there is only one member, the expression is equivalent to the member expression.",
+            DataType.TUPLE,
+            param(DataType.MEMBER, "Member").repeatable(1)));
+
+    @Override
+    public List<FunctionMetaData> getRepresentativeFunctionMetaDatas() {
+        return REPRESENTATIVE_METADATAS;
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/tupleitem/TupleItemFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/tupleitem/TupleItemFunDef.java
@@ -35,7 +35,7 @@ public class TupleItemFunDef extends AbstractFunctionDefinition {
     static OperationAtom functionAtom = new MethodOperationAtom("Item");
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom, "Returns a member from the tuple specified in <Tuple>. The member to be returned is specified by the zero-based position of the member in the set in <Index>.",
-            DataType.MEMBER, new FunctionParameterR[] { new FunctionParameterR(DataType.TUPLE), new FunctionParameterR(DataType.NUMERIC, "Index") });
+            DataType.MEMBER, new FunctionParameterR[] { FunctionParameterR.param(DataType.TUPLE), FunctionParameterR.param(DataType.NUMERIC, "Index") });
 
     static final TupleItemFunDef instance = new TupleItemFunDef();
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/tupletostr/TupleToStrFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/tupletostr/TupleToStrFunDef.java
@@ -32,7 +32,7 @@ public class TupleToStrFunDef extends AbstractFunctionDefinition {
     static OperationAtom functionAtom = new FunctionOperationAtom("TupleToStr");
 
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(functionAtom, "Constructs a string from a tuple.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(DataType.TUPLE) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.TUPLE) });
 
     static final TupleToStrFunDef instance = new TupleToStrFunDef();
 

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/currentdatemember/CurrentDateMemberResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/currentdatemember/CurrentDateMemberResolver.java
@@ -18,7 +18,9 @@ import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionOrigin;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
@@ -37,24 +39,14 @@ public class CurrentDateMemberResolver extends AbstractFunctionDefinitionMultiRe
             namely the Visual Basic format strings.
             See http://www.apostate.com/programming/vb-format.html.""";
 
-    private final static String DESCRIPTION1 = """
-            Returns the exact member within the specified dimension
-            corresponding to the current date, in the format specified by
-            the format parameter.
-            If there is no such date, returns the NULL member.
-            Format strings are the same as used by the MDX Format function,
-            namely the Visual Basic format strings.
-            See http://www.apostate.com/programming/vb-format.html.""";
-
-    private static FunctionParameterR[] fp = { new FunctionParameterR(DataType.HIERARCHY),
-            new FunctionParameterR(DataType.STRING, "Format"), new FunctionParameterR(DataType.SYMBOL, "MatchType", Optional.of(reservedWords)) };
-    private static FunctionParameterR[] fp1 = { new FunctionParameterR(DataType.HIERARCHY),
-            new FunctionParameterR(DataType.STRING, "Format") };
+    private static FunctionParameterR[] fp = { FunctionParameterR.param(DataType.HIERARCHY),
+            FunctionParameterR.param(DataType.STRING, "Format"),
+            new FunctionParameterR(DataType.SYMBOL, "MatchType", Optional.of(reservedWords))
+                    .describedAs("EXACT (default), BEFORE or AFTER — how the current date is matched to a member.")
+                    .asOptional() };
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.MEMBER, fp);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION1,
-            DataType.MEMBER, fp1);
+            DataType.MEMBER, fp).interfaceName(FunctionInterface.DATETIME).origin(FunctionOrigin.UDF).library("daanse.udf");
 
     @Override
     public List<String> getReservedWords() {
@@ -62,7 +54,7 @@ public class CurrentDateMemberResolver extends AbstractFunctionDefinitionMultiRe
     }
 
     public CurrentDateMemberResolver() {
-        super(List.of(new CurrentDateMemberFunDef(functionMetaData), new CurrentDateMemberFunDef(functionMetaData1)));
+        super(List.of(new CurrentDateMemberFunDef(functionMetaData)));
     }
 
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/currentdatestring/CurrentDateStringFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/currentdatestring/CurrentDateStringFunDef.java
@@ -18,7 +18,9 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.StringCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionOrigin;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
@@ -29,7 +31,7 @@ public class CurrentDateStringFunDef  extends AbstractFunctionDefinition {
     static FunctionOperationAtom atom = new FunctionOperationAtom("CurrentDateString");
     static String description = "Returns the current date formatted as specified by the format parameter.";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.STRING , new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "Format") });
+            DataType.STRING , new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "Format") }).interfaceName(FunctionInterface.DATETIME).origin(FunctionOrigin.UDF).library("daanse.udf");
 
     public CurrentDateStringFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/in/InFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/in/InFunDef.java
@@ -20,6 +20,7 @@ import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionOrigin;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
@@ -31,7 +32,7 @@ public class InFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns true if the member argument is contained in the set argument.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.LOGICAL , new FunctionParameterR[] { new FunctionParameterR( DataType.MEMBER ), new FunctionParameterR( DataType.SET ) });
+            DataType.LOGICAL , new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER), FunctionParameterR.param(DataType.SET) }).origin(FunctionOrigin.UDF).library("daanse.udf");
 
     public InFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/lastnonempty/LastNonEmptyFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/lastnonempty/LastNonEmptyFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionOrigin;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
@@ -30,7 +31,7 @@ public class LastNonEmptyFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the last member of a set whose value is not empty""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.MEMBER , new FunctionParameterR[] { new FunctionParameterR( DataType.SET ), new FunctionParameterR( DataType.MEMBER ) });
+            DataType.MEMBER , new FunctionParameterR[] { FunctionParameterR.param(DataType.SET), FunctionParameterR.param(DataType.MEMBER) }).origin(FunctionOrigin.UDF).library("daanse.udf");
 
     public LastNonEmptyFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/matches/MatchesFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/matches/MatchesFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.StringCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionOrigin;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
@@ -30,7 +31,7 @@ public class MatchesFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns true if the string matches the regular expression.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.LOGICAL , new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "String" ), new FunctionParameterR( DataType.STRING, "regex" ) });
+            DataType.LOGICAL , new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String"), FunctionParameterR.param(DataType.STRING, "regex") }).origin(FunctionOrigin.UDF).library("daanse.udf");
 
     public MatchesFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/nullvalue/NullValueFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/nullvalue/NullValueFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionOrigin;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
@@ -29,7 +30,7 @@ public class NullValueFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns the null value""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC , new FunctionParameterR[] { });
+            DataType.NUMERIC , new FunctionParameterR[] { }).origin(FunctionOrigin.UDF).library("daanse.udf");
 
     public NullValueFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/val/ValFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/udf/val/ValFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.DoubleCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionOrigin;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
 import org.eclipse.daanse.olap.function.core.FunctionParameterR;
@@ -29,7 +30,7 @@ public class ValFunDef  extends AbstractFunctionDefinition {
     static FunctionOperationAtom atom = new FunctionOperationAtom("Val");
     static String description = "VB function Val";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC , new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "Value" ) });
+            DataType.NUMERIC , new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "Value") }).origin(FunctionOrigin.UDF).library("daanse.udf");
 
     public ValFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/union/UnionResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/union/UnionResolver.java
@@ -30,18 +30,17 @@ public class UnionResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Union");
     static final List<String> ReservedWords = List.of("ALL", "DISTINCT");
     private static String DESCRIPTION = "Returns the union of two sets, optionally retaining duplicates.";
-    private static FunctionParameterR[] xx = { new FunctionParameterR(DataType.SET, "Set1"), new FunctionParameterR(DataType.SET, "Set2") };
-    private static FunctionParameterR[] xxy = { new FunctionParameterR(DataType.SET, "Set1"), new FunctionParameterR(DataType.SET, "Set2"),
-            new FunctionParameterR(DataType.SYMBOL, "ALL", Optional.of(ReservedWords)) };
+    private static FunctionParameterR[] xxy = { FunctionParameterR.param(DataType.SET, "Set1"),
+            FunctionParameterR.param(DataType.SET, "Set2"),
+            new FunctionParameterR(DataType.SYMBOL, "ALL", Optional.of(ReservedWords))
+                    .describedAs("ALL retains duplicates; DISTINCT (default) removes them.").asOptional() };
     // {"fxxx", "fxxxy"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xx);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
             DataType.SET, xxy);
 
     public UnionResolver() {
-        super(List.of(new UnionFunDef(functionMetaData), new UnionFunDef(functionMetaData1)));
+        super(List.of(new UnionFunDef(functionMetaData)));
     }
     
     @Override

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/dimension/UniqueNameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/dimension/UniqueNameFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.DimensionCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class UniqueNameFunDef extends AbstractFunctionDefinition {
     // <Dimension>.UniqueName
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("UniqueName");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom, "Returns the unique name of a dimension.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.DIMENSION ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.DIMENSION) }).interfaceName(FunctionInterface.METADATA);
 
     public UniqueNameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/hierarchy/UniqueNameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/hierarchy/UniqueNameFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.HierarchyCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class UniqueNameFunDef extends AbstractFunctionDefinition {
     // <Hierarchy>.UniqueName
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("UniqueName");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom, "Returns the unique name of a hierarchy.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR( DataType.HIERARCHY ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.HIERARCHY) }).interfaceName(FunctionInterface.METADATA);
 
     public UniqueNameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/level/UniqueNameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/level/UniqueNameFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.LevelCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class UniqueNameFunDef extends AbstractFunctionDefinition {
     // <Level>.UniqueName
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("UniqueName");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom, "Returns the unique name of a level.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.LEVEL ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.LEVEL) }).interfaceName(FunctionInterface.METADATA);
 
     public UniqueNameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/member/UniqueNameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/member/UniqueNameFunDef.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -30,7 +31,7 @@ public class UniqueNameFunDef extends AbstractFunctionDefinition {
     // <Member>.UniqueName
     static OperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("UniqueName");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom, "Returns the unique name of a member.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.METADATA);
 
     public UniqueNameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/member/Unique_NameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/uniquename/member/Unique_NameFunDef.java
@@ -18,6 +18,7 @@ import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.MemberCalc;
 import org.eclipse.daanse.olap.api.calc.compiler.ExpressionCompiler;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -29,7 +30,7 @@ public class Unique_NameFunDef extends AbstractFunctionDefinition {
     // <Member>.Unique_Name
     static PlainPropertyOperationAtom plainPropertyOperationAtom = new PlainPropertyOperationAtom("Unique_Name");
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(plainPropertyOperationAtom, "Returns the unique name of a member.",
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR(  DataType.MEMBER ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.MEMBER) }).interfaceName(FunctionInterface.METADATA);
 
     public Unique_NameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/unorder/UnorderResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/unorder/UnorderResolver.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
 public class UnorderResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Unorder");
     private static String DESCRIPTION = "Removes any enforced ordering from a specified set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
+    private static FunctionParameterR[] x = { FunctionParameterR.param(DataType.SET) };
     // {"fxx"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/var/VarPResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/var/VarPResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class VarPResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("VarP");
     private static String DESCRIPTION = "Returns the variance of a numeric expression evaluated over a set (biased).";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Value") };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Value").asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public VarPResolver() {
-        super(List.of(new VarPFunDef(functionMetaData), new VarPFunDef(functionMetaData1)));
+        super(List.of(new VarPFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/var/VarResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/var/VarResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class VarResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Var");
     private static String DESCRIPTION = "Returns the variance of a numeric expression evaluated over a set (unbiased).";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC, "Value") };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC, "Value").asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public VarResolver() {
-        super(List.of(new VarFunDef(functionMetaData), new VarFunDef(functionMetaData1)));
+        super(List.of(new VarFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/var/VariancePResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/var/VariancePResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class VariancePResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("VarianceP");
     private static String DESCRIPTION = "Alias for VarP.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC).asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public VariancePResolver() {
-        super(List.of(new VarPFunDef(functionMetaData), new VarPFunDef(functionMetaData1)));
+        super(List.of(new VarPFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/var/VarianceResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/var/VarianceResolver.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -28,17 +29,14 @@ import org.osgi.service.component.annotations.Component;
 public class VarianceResolver extends AbstractFunctionDefinitionMultiResolver {
     private static FunctionOperationAtom atom = new FunctionOperationAtom("Variance");
     private static String DESCRIPTION = "Alias for Var.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xn = { new FunctionParameterR(DataType.SET),
-            new FunctionParameterR(DataType.NUMERIC) };
+    private static FunctionParameterR[] xn = { FunctionParameterR.param(DataType.SET),
+            FunctionParameterR.param(DataType.NUMERIC).asOptional() };
     // {"fnx", "fnxn"}
 
     private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, xn);
+            DataType.NUMERIC, xn).interfaceName(FunctionInterface.STATISTICAL);
 
     public VarianceResolver() {
-        super(List.of(new VarFunDef(functionMetaData), new VarFunDef(functionMetaData1)));
+        super(List.of(new VarFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/abs/AbsFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/abs/AbsFunDef.java
@@ -32,7 +32,7 @@ public class AbsFunDef  extends AbstractFunctionDefinition {
         absolute value of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public AbsFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/asc/AscBFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/asc/AscBFunDef.java
@@ -32,7 +32,7 @@ public class AscBFunDef  extends AbstractFunctionDefinition {
         the first letter in a string.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.INTEGER, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.STRING, "String" )});
+                    FunctionParameterR.param(DataType.STRING, "String")});
 
     public AscBFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/asc/AscFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/asc/AscFunDef.java
@@ -32,7 +32,7 @@ public class AscFunDef  extends AbstractFunctionDefinition {
         the first letter in a string.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.INTEGER, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.STRING, "String" )});
+                    FunctionParameterR.param(DataType.STRING, "String")});
 
     public AscFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/asc/AscWFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/asc/AscWFunDef.java
@@ -32,7 +32,7 @@ public class AscWFunDef  extends AbstractFunctionDefinition {
         the first letter in a string.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.INTEGER, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.STRING, "String" )});
+                    FunctionParameterR.param(DataType.STRING, "String")});
 
     public AscWFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/atn/AtnFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/atn/AtnFunDef.java
@@ -31,7 +31,7 @@ public class AtnFunDef  extends AbstractFunctionDefinition {
         Returns a Double specifying the arctangent of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public AtnFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cbool/CBoolFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cbool/CBoolFunDef.java
@@ -29,7 +29,7 @@ public class CBoolFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns an expression that has been converted to a Variant of subtype Boolean.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "Expression" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "Expression") });
 
     public CBoolFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cbyte/CByteFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cbyte/CByteFunDef.java
@@ -29,7 +29,7 @@ public class CByteFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns an expression that has been converted to a Variant of subtype Boolean.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "expression" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "expression") });
 
     public CByteFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cdate/CDateFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cdate/CDateFunDef.java
@@ -29,7 +29,7 @@ public class CDateFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns an expression that has been converted to a Variant of subtype""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.DATE_TIME, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "expression" ) });
+            DataType.DATE_TIME, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "expression") });
 
     public CDateFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cdbl/CDblFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cdbl/CDblFunDef.java
@@ -29,7 +29,7 @@ public class CDblFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns an expression that has been converted to a Variant of subtype Double.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "expression" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "expression") });
 
     public CDblFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/chr/ChrBFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/chr/ChrBFunDef.java
@@ -32,7 +32,7 @@ public class ChrBFunDef extends AbstractFunctionDefinition {
         the first letter in a string.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.INTEGER, "charcode" )});
+                    FunctionParameterR.param(DataType.INTEGER, "charcode")});
 
     public ChrBFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/chr/ChrFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/chr/ChrFunDef.java
@@ -32,7 +32,7 @@ public class ChrFunDef  extends AbstractFunctionDefinition {
         the first letter in a string.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.INTEGER, "charcode" )});
+                    FunctionParameterR.param(DataType.INTEGER, "charcode")});
 
     public ChrFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/chr/ChrWFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/chr/ChrWFunDef.java
@@ -32,7 +32,7 @@ public class ChrWFunDef  extends AbstractFunctionDefinition {
         the first letter in a string.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.INTEGER, "charcode" )});
+                    FunctionParameterR.param(DataType.INTEGER, "charcode")});
 
     public ChrWFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cint/CIntFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cint/CIntFunDef.java
@@ -30,7 +30,7 @@ public class CIntFunDef  extends AbstractFunctionDefinition {
         Returns an expression that has been converted to a Variant of subtype
         Integer.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.NUMERIC, "expression" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.NUMERIC, "expression") });
 
     public CIntFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cos/CosFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/cos/CosFunDef.java
@@ -31,7 +31,7 @@ public class CosFunDef  extends AbstractFunctionDefinition {
         Returns a Double specifying the cosine of an angle.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public CosFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/dateadd/DateAddFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/dateadd/DateAddFunDef.java
@@ -33,8 +33,8 @@ public class DateAddFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Date) containing a date to which a specified time
         interval has been added.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.DATE_TIME, new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "IntervalName" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Number" ), new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.DATE_TIME, new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "IntervalName"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Number"), FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public DateAddFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/datediff/DateDiffResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/datediff/DateDiffResolver.java
@@ -31,24 +31,15 @@ public class DateDiffResolver extends AbstractFunctionDefinitionMultiResolver {
     private static String DESCRIPTION = """
             Returns a Variant (Long) specifying the number of time intervals
             between two specified dates.""";
-    private static FunctionParameterR[] p1 = { new FunctionParameterR( DataType.STRING, "IntervalName" ), new FunctionParameterR( DataType.DATE_TIME, "Date1" ),
-            new FunctionParameterR( DataType.DATE_TIME, "Date2" ) };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR( DataType.STRING, "IntervalName" ), 
-            new FunctionParameterR( DataType.DATE_TIME, "Date1" ), new FunctionParameterR( DataType.DATE_TIME, "Date2" ),
-            new FunctionParameterR( DataType.INTEGER, "First Day Of Week" ) };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR( DataType.STRING, "IntervalName" ),
-            new FunctionParameterR( DataType.DATE_TIME, "Date1" ), new FunctionParameterR( DataType.DATE_TIME, "Date2" ),
-            new FunctionParameterR( DataType.INTEGER, "First Day Of Week" ), new FunctionParameterR( DataType.INTEGER, "First Week Of Year" ) };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "IntervalName"),
+            FunctionParameterR.param(DataType.DATE_TIME, "Date1"), FunctionParameterR.param(DataType.DATE_TIME, "Date2"),
+            FunctionParameterR.param(DataType.INTEGER, "First Day Of Week").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "First Week Of Year").asOptional() };
 
-
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p3);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public DateDiffResolver() {
-        super(List.of(new DateDiffFunDef(functionMetaData1), new DateDiffFunDef(functionMetaData2), new DateDiffFunDef(functionMetaData3)));
+        super(List.of(new DateDiffFunDef(functionMetaData)));
     }
 }    

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/datepart/DatePartFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/datepart/DatePartFunDef.java
@@ -39,15 +39,15 @@ public class DatePartFunDef  extends AbstractFunctionDefinition {
         final DateTimeCalc dateTimeCalc = compiler.compileDateTime(call.getArg(1));
         IntegerCalc firstDayOfWeek = null;
         IntegerCalc firstWeekOfYear = null;
-        if (call.getArgCount() == 2) {
+        if (call.getArgCount() == 3) {
             firstDayOfWeek = new ConstantIntegerCalc(new DecimalType(Integer.MAX_VALUE, 0), Calendar.SUNDAY);
             firstWeekOfYear = new ConstantIntegerCalc(new DecimalType(Integer.MAX_VALUE, 0), 1);
         }
-        if (call.getArgCount() == 3) {
+        if (call.getArgCount() == 4) {
             firstDayOfWeek = compiler.compileInteger(call.getArg(3));
             firstWeekOfYear = new ConstantIntegerCalc(new DecimalType(Integer.MAX_VALUE, 0), 1);
         }
-        if (call.getArgCount() == 4) {
+        if (call.getArgCount() == 5) {
             firstDayOfWeek = compiler.compileInteger(call.getArg(3));
             firstWeekOfYear = compiler.compileInteger(call.getArg(4));
         }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/datepart/DatePartResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/datepart/DatePartResolver.java
@@ -31,24 +31,15 @@ public class DatePartResolver extends AbstractFunctionDefinitionMultiResolver {
     private static String DESCRIPTION = """
             Returns a Variant (Integer) containing the specified part of a given
             date.""";
-    private static FunctionParameterR[] p1 = { new FunctionParameterR( DataType.STRING, "IntervalName" ), new FunctionParameterR( DataType.DATE_TIME, "Date1" ),
-            new FunctionParameterR( DataType.DATE_TIME, "Date2" ) };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR( DataType.STRING, "IntervalName" ), 
-            new FunctionParameterR( DataType.DATE_TIME, "Date1" ), new FunctionParameterR( DataType.DATE_TIME, "Date2" ),
-            new FunctionParameterR( DataType.INTEGER, "First Day Of Week" ) };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR( DataType.STRING, "IntervalName" ),
-            new FunctionParameterR( DataType.DATE_TIME, "Date1" ), new FunctionParameterR( DataType.DATE_TIME, "Date2" ),
-            new FunctionParameterR( DataType.INTEGER, "First Day Of Week" ), new FunctionParameterR( DataType.INTEGER, "First Week Of Year" ) };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "IntervalName"),
+            FunctionParameterR.param(DataType.DATE_TIME, "Date1"), FunctionParameterR.param(DataType.DATE_TIME, "Date2"),
+            FunctionParameterR.param(DataType.INTEGER, "First Day Of Week").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "First Week Of Year").asOptional() };
 
-
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p3);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public DatePartResolver() {
-        super(List.of(new DatePartFunDef(functionMetaData1), new DatePartFunDef(functionMetaData2), new DatePartFunDef(functionMetaData3)));
+        super(List.of(new DatePartFunDef(functionMetaData)));
     }
 }    

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/dateserial/DateSerialFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/dateserial/DateSerialFunDef.java
@@ -30,7 +30,7 @@ public class DateSerialFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns a Variant (Date) for a specified year, month, and day.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.DATE_TIME, new FunctionParameterR[] { new FunctionParameterR( DataType.INTEGER, "Year" ), new FunctionParameterR( DataType.INTEGER, "Month" ), new FunctionParameterR( DataType.INTEGER, "Day" ) });
+            DataType.DATE_TIME, new FunctionParameterR[] { FunctionParameterR.param(DataType.INTEGER, "Year"), FunctionParameterR.param(DataType.INTEGER, "Month"), FunctionParameterR.param(DataType.INTEGER, "Day") });
 
     public DateSerialFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/datevalue/DateValueFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/datevalue/DateValueFunDef.java
@@ -30,7 +30,7 @@ public class DateValueFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns a Variant (Date) for a specified year, month, and day.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.DATE_TIME, new FunctionParameterR[] { new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.DATE_TIME, new FunctionParameterR[] { FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public DateValueFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/day/DayFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/day/DayFunDef.java
@@ -31,7 +31,7 @@ public class DayFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Integer) specifying a whole number between 1 and
         31, inclusive, representing the day of the month.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public DayFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ddb/DDBResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ddb/DDBResolver.java
@@ -33,15 +33,15 @@ public class DDBResolver extends AbstractFunctionDefinitionMultiResolver {
             specific time period using the double-declining balance method or
             some other method you specify.""";
     
-    private static FunctionParameterR[] p1 = { new FunctionParameterR( DataType.NUMERIC, "Cost" ), new FunctionParameterR( DataType.NUMERIC, "Salvage" ), new FunctionParameterR( DataType.NUMERIC, "Life" ) , new FunctionParameterR( DataType.NUMERIC, "Period" )};
-    private static FunctionParameterR[] p2 = { new FunctionParameterR( DataType.NUMERIC, "Cost" ), new FunctionParameterR( DataType.NUMERIC, "Salvage" ), new FunctionParameterR( DataType.NUMERIC, "Life" ), new FunctionParameterR( DataType.NUMERIC, "Period" ), new FunctionParameterR( DataType.NUMERIC, "Factor" ) };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.NUMERIC, "Cost"),
+            FunctionParameterR.param(DataType.NUMERIC, "Salvage"), FunctionParameterR.param(DataType.NUMERIC, "Life"),
+            FunctionParameterR.param(DataType.NUMERIC, "Period"),
+            FunctionParameterR.param(DataType.NUMERIC, "Factor").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public DDBResolver() {
-        super(List.of(new DDBFunDef(functionMetaData1), new DDBFunDef(functionMetaData2)));
+        super(List.of(new DDBFunDef(functionMetaData)));
     }
 }    

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/exp/ExpFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/exp/ExpFunDef.java
@@ -32,7 +32,7 @@ public class ExpFunDef  extends AbstractFunctionDefinition {
         raised to a power.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public ExpFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/fix/FixFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/fix/FixFunDef.java
@@ -30,7 +30,7 @@ public class FixFunDef  extends AbstractFunctionDefinition {
         Returns an expression that has been converted to a Variant of subtype
         Integer.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "expression" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "expression") });
 
     public FixFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/formatcurrency/FormatCurrencyResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/formatcurrency/FormatCurrencyResolver.java
@@ -32,32 +32,16 @@ public class FormatCurrencyResolver extends AbstractFunctionDefinitionMultiResol
         Returns an expression formatted as a currency value using the
         currency symbol defined in the system control panel.""";
 
-    private static FunctionParameterR[] p0 = { new FunctionParameterR(DataType.VALUE, "expression") };
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.VALUE, "expression"),
-            new FunctionParameterR(DataType.INTEGER, "numDigitsAfterDecimal")};
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.VALUE, "expression"),
-            new FunctionParameterR(DataType.INTEGER, "numDigitsAfterDecimal"), new FunctionParameterR(DataType.INTEGER, "includeLeadingDigit") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.VALUE, "expression"),
-            new FunctionParameterR(DataType.INTEGER, "numDigitsAfterDecimal"), new FunctionParameterR(DataType.INTEGER, "includeLeadingDigit"),
-            new FunctionParameterR(DataType.INTEGER, "useParensForNegativeNumbers") };
-    private static FunctionParameterR[] p4 = { new FunctionParameterR(DataType.VALUE, "expression"),
-            new FunctionParameterR(DataType.INTEGER, "numDigitsAfterDecimal"), new FunctionParameterR(DataType.INTEGER, "includeLeadingDigit"),
-            new FunctionParameterR(DataType.INTEGER, "useParensForNegativeNumbers"), new FunctionParameterR(DataType.INTEGER, "groupDigits") };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.VALUE, "expression"),
+            FunctionParameterR.param(DataType.INTEGER, "numDigitsAfterDecimal").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "includeLeadingDigit").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "useParensForNegativeNumbers").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "groupDigits").asOptional() };
 
-
-    private static FunctionMetaData functionMetaData0 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p0);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p3);
-    private static FunctionMetaData functionMetaData4 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p4);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.STRING, params);
 
     public FormatCurrencyResolver() {
-        super(List.of(new FormatCurrencyFunDef(functionMetaData0), new FormatCurrencyFunDef(functionMetaData1), new FormatCurrencyFunDef(functionMetaData2),
-                new FormatCurrencyFunDef(functionMetaData3), new FormatCurrencyFunDef(functionMetaData4)));
+        super(List.of(new FormatCurrencyFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/formatdatetime/FormatDateTimeResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/formatdatetime/FormatDateTimeResolver.java
@@ -31,15 +31,13 @@ public class FormatDateTimeResolver extends AbstractFunctionDefinitionMultiResol
     private static String DESCRIPTION = """
         Returns an expression formatted as a date or time.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.DATE_TIME, "Date") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.DATE_TIME, "Date"), new FunctionParameterR(DataType.INTEGER, "Named Format") };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.DATE_TIME, "Date"),
+            FunctionParameterR.param(DataType.INTEGER, "Named Format").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p2);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.STRING, params);
 
     public FormatDateTimeResolver() {
-        super(List.of(new FormatDateTimeFunDef(functionMetaData1), new FormatDateTimeFunDef(functionMetaData2)));
+        super(List.of(new FormatDateTimeFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/formatnumber/FormatNumberResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/formatnumber/FormatNumberResolver.java
@@ -31,32 +31,16 @@ public class FormatNumberResolver extends AbstractFunctionDefinitionMultiResolve
     private static String DESCRIPTION = """
         Returns an expression formatted as a number.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.VALUE, "Expression") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.VALUE, "Expression"),
-            new FunctionParameterR(DataType.INTEGER, "Digits After Decimal") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.VALUE, "Expression"),
-            new FunctionParameterR(DataType.INTEGER, "Digits After Decimal"), new FunctionParameterR(DataType.INTEGER, "Include Leading Digit") };
-    private static FunctionParameterR[] p4 = { new FunctionParameterR(DataType.VALUE, "Expression"),
-            new FunctionParameterR(DataType.INTEGER, "Digits After Decimal"), new FunctionParameterR(DataType.INTEGER, "Include Leading Digit"),
-            new FunctionParameterR(DataType.INTEGER, "Use Parens For Negative Numbers") };
-    private static FunctionParameterR[] p5 = { new FunctionParameterR(DataType.VALUE, "Expression"),
-            new FunctionParameterR(DataType.INTEGER, "Digits After Decimal"), new FunctionParameterR(DataType.INTEGER, "Include Leading Digit"),
-            new FunctionParameterR(DataType.INTEGER, "Use Parens For Negative Numbers"), new FunctionParameterR(DataType.INTEGER, "Group Digits") };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.VALUE, "Expression"),
+            FunctionParameterR.param(DataType.INTEGER, "Digits After Decimal").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "Include Leading Digit").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "Use Parens For Negative Numbers").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "Group Digits").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p3);
-    private static FunctionMetaData functionMetaData4 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p4);
-    private static FunctionMetaData functionMetaData5 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p5);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.STRING, params);
 
     public FormatNumberResolver() {
-        super(List.of(new FormatNumberFunDef(functionMetaData1), new FormatNumberFunDef(functionMetaData2),
-                new FormatNumberFunDef(functionMetaData3), new FormatNumberFunDef(functionMetaData4),
-                new FormatNumberFunDef(functionMetaData5)));
+        super(List.of(new FormatNumberFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/formatpercent/FormatPercentResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/formatpercent/FormatPercentResolver.java
@@ -32,30 +32,16 @@ public class FormatPercentResolver extends AbstractFunctionDefinitionMultiResolv
         Returns an expression formatted as a percentage (multipled by 100)
         with a trailing % character.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.VALUE, "Expression") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.VALUE, "Expression"), new FunctionParameterR(DataType.INTEGER, "Digits After Decimal") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.VALUE, "Expression"), new FunctionParameterR(DataType.INTEGER, "Digits After Decimal"),
-            new FunctionParameterR(DataType.INTEGER, "Include Leading Digit")};
-    private static FunctionParameterR[] p4 = { new FunctionParameterR(DataType.VALUE, "Expression"), new FunctionParameterR(DataType.INTEGER, "Digits After Decimal"),
-            new FunctionParameterR(DataType.INTEGER, "Include Leading Digit"), new FunctionParameterR(DataType.INTEGER, "Use Parens For Negative Numbers")};
-    private static FunctionParameterR[] p5 = { new FunctionParameterR(DataType.VALUE, "Expression"), new FunctionParameterR(DataType.INTEGER, "Digits After Decimal"),
-            new FunctionParameterR(DataType.INTEGER, "Include Leading Digit"), new FunctionParameterR(DataType.INTEGER, "Use Parens For Negative Numbers"),
-            new FunctionParameterR(DataType.INTEGER, "Group Digits")};
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.VALUE, "Expression"),
+            FunctionParameterR.param(DataType.INTEGER, "Digits After Decimal").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "Include Leading Digit").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "Use Parens For Negative Numbers").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "Group Digits").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p3);
-    private static FunctionMetaData functionMetaData4 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p4);
-    private static FunctionMetaData functionMetaData5 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p5);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.STRING, params);
 
     public FormatPercentResolver() {
-        super(List.of(new FormatPercentFunDef(functionMetaData1), new FormatPercentFunDef(functionMetaData2),
-                new FormatPercentFunDef(functionMetaData3), new FormatPercentFunDef(functionMetaData4),
-                new FormatPercentFunDef(functionMetaData5)));
+        super(List.of(new FormatPercentFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/fv/FVResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/fv/FVResolver.java
@@ -32,24 +32,15 @@ public class FVResolver extends AbstractFunctionDefinitionMultiResolver {
             Returns a Double specifying the future value of an annuity based on
             periodic, fixed payments and a fixed interest rate.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "NPer"), new FunctionParameterR(DataType.NUMERIC, "Pmt") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "NPer"), new FunctionParameterR(DataType.NUMERIC, "Pmt"),
-            new FunctionParameterR(DataType.NUMERIC, "Pv") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "NPer"), new FunctionParameterR(DataType.NUMERIC, "Pmt"),
-            new FunctionParameterR(DataType.NUMERIC, "Pv"), new FunctionParameterR(DataType.LOGICAL, "Type") };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.NUMERIC, "Rate"),
+            FunctionParameterR.param(DataType.NUMERIC, "NPer"), FunctionParameterR.param(DataType.NUMERIC, "Pmt"),
+            FunctionParameterR.param(DataType.NUMERIC, "Pv").asOptional(),
+            FunctionParameterR.param(DataType.LOGICAL, "Type").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p3);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public FVResolver() {
-        super(List.of(new FVFunDef(functionMetaData1), new FVFunDef(functionMetaData2),
-                new FVFunDef(functionMetaData3)));
+        super(List.of(new FVFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/hex/HexFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/hex/HexFunDef.java
@@ -29,7 +29,7 @@ public class HexFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns a String representing the hexadecimal value of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "number" ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "number") });
 
     public HexFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/hour/HourFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/hour/HourFunDef.java
@@ -31,7 +31,7 @@ public class HourFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Integer) specifying a whole number between 0 and
         23, inclusive, representing the hour of the day.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public HourFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/instr/InStrResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/instr/InStrResolver.java
@@ -32,12 +32,12 @@ public class InStrResolver extends AbstractFunctionDefinitionMultiResolver {
         Returns a Variant (Long) specifying the position of the first
         occurrence of one string within another.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.STRING, "String Check"), new FunctionParameterR(DataType.STRING, "String Match") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.INTEGER, "Start"), new FunctionParameterR(DataType.STRING, "String Check"),
-            new FunctionParameterR(DataType.STRING, "String Match") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.INTEGER, "Start"), new FunctionParameterR(DataType.STRING, "String Check"),
-            new FunctionParameterR(DataType.STRING, "String Match"),
-            new FunctionParameterR(DataType.INTEGER, "Compare") };
+    private static FunctionParameterR[] p1 = { FunctionParameterR.param(DataType.STRING, "String Check"), FunctionParameterR.param(DataType.STRING, "String Match") };
+    private static FunctionParameterR[] p2 = { FunctionParameterR.param(DataType.INTEGER, "Start"), FunctionParameterR.param(DataType.STRING, "String Check"),
+            FunctionParameterR.param(DataType.STRING, "String Match") };
+    private static FunctionParameterR[] p3 = { FunctionParameterR.param(DataType.INTEGER, "Start"), FunctionParameterR.param(DataType.STRING, "String Check"),
+            FunctionParameterR.param(DataType.STRING, "String Match"),
+            FunctionParameterR.param(DataType.INTEGER, "Compare") };
 
     private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
             DataType.INTEGER, p1);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/instrrev/InStrRevResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/instrrev/InStrRevResolver.java
@@ -32,21 +32,15 @@ public class InStrRevResolver extends AbstractFunctionDefinitionMultiResolver {
         Returns the position of an occurrence of one string within another,
         from the end of string.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.STRING, "String Check"), new FunctionParameterR(DataType.STRING, "String Match") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.STRING, "String Check"),
-            new FunctionParameterR(DataType.STRING, "String Match"), new FunctionParameterR(DataType.INTEGER, "Start") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.STRING, "String Check"),
-            new FunctionParameterR(DataType.STRING, "String Match"), new FunctionParameterR(DataType.INTEGER, "Start"),
-            new FunctionParameterR(DataType.INTEGER, "Compare") };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "String Check"),
+            FunctionParameterR.param(DataType.STRING, "String Match"),
+            FunctionParameterR.param(DataType.INTEGER, "Start").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "Compare").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, p3);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.INTEGER, params);
 
     public InStrRevResolver() {
-        super(List.of(new InStrRevFunDef(functionMetaData1), new InStrRevFunDef(functionMetaData2), new InStrRevFunDef(functionMetaData3)));
+        super(List.of(new InStrRevFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/integer/IntFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/integer/IntFunDef.java
@@ -30,7 +30,7 @@ public class IntFunDef  extends AbstractFunctionDefinition {
         Returns the integer portion of a number. If negative, returns the
         negative number less than or equal to the number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "expression" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "expression") });
 
     public IntFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ipmt/IPmtResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ipmt/IPmtResolver.java
@@ -33,26 +33,16 @@ public class IPmtResolver extends AbstractFunctionDefinitionMultiResolver {
             of an annuity based on periodic, fixed payments and a fixed
             interest rate.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "Per"), new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pv") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "Per"), new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pv"), new FunctionParameterR(DataType.NUMERIC, "Fv") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "Per"), new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pv"), new FunctionParameterR(DataType.NUMERIC, "Fv"),
-            new FunctionParameterR(DataType.LOGICAL, "due") };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.NUMERIC, "Rate"),
+            FunctionParameterR.param(DataType.NUMERIC, "Per"), FunctionParameterR.param(DataType.NUMERIC, "NPer"),
+            FunctionParameterR.param(DataType.NUMERIC, "Pv"),
+            FunctionParameterR.param(DataType.NUMERIC, "Fv").asOptional(),
+            FunctionParameterR.param(DataType.LOGICAL, "due").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p3);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public IPmtResolver() {
-        super(List.of(new IPmtFunDef(functionMetaData1), new IPmtFunDef(functionMetaData2),
-                new IPmtFunDef(functionMetaData3)));
+        super(List.of(new IPmtFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/irr/IRRResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/irr/IRRResolver.java
@@ -32,16 +32,13 @@ public class IRRResolver extends AbstractFunctionDefinitionMultiResolver {
             Returns a Double specifying the internal rate of return for a series
             of periodic cash flows (payments and receipts).""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.ARRAY, "ValueArray") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.ARRAY, "ValueArray"),
-            new FunctionParameterR(DataType.NUMERIC, "Guess") };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.ARRAY, "ValueArray"),
+            FunctionParameterR.param(DataType.NUMERIC, "Guess").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public IRRResolver() {
-        super(List.of(new IRRFunDef(functionMetaData1), new IRRFunDef(functionMetaData2)));
+        super(List.of(new IRRFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isarray/IsArrayFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isarray/IsArrayFunDef.java
@@ -30,7 +30,7 @@ public class IsArrayFunDef  extends AbstractFunctionDefinition {
         Returns a Boolean value indicating whether a variable is an array.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.LOGICAL, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.VALUE, "VarName" )});
+                    FunctionParameterR.param(DataType.VALUE, "VarName")});
 
     public IsArrayFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isdate/IsDateFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isdate/IsDateFunDef.java
@@ -30,7 +30,7 @@ public class IsDateFunDef  extends AbstractFunctionDefinition {
         Returns a Boolean value indicating whether an expression can be
         converted to a date.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.LOGICAL, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "expression" ) });
+            DataType.LOGICAL, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "expression") });
 
     public IsDateFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/iserror/IsErrorFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/iserror/IsErrorFunDef.java
@@ -31,7 +31,7 @@ public class IsErrorFunDef  extends AbstractFunctionDefinition {
         value.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.LOGICAL, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.VALUE, "VarName" )});
+                    FunctionParameterR.param(DataType.VALUE, "VarName")});
 
     public IsErrorFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ismissing/IsMissingFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ismissing/IsMissingFunDef.java
@@ -31,7 +31,7 @@ public class IsMissingFunDef  extends AbstractFunctionDefinition {
         argument has been passed to a procedure.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.LOGICAL, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.VALUE, "VarName" )});
+                    FunctionParameterR.param(DataType.VALUE, "VarName")});
 
     public IsMissingFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isnull/IsNullFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isnull/IsNullFunDef.java
@@ -31,7 +31,7 @@ public class IsNullFunDef  extends AbstractFunctionDefinition {
         contains no valid data (Null).""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.LOGICAL, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.VALUE, "VarName" )});
+                    FunctionParameterR.param(DataType.VALUE, "VarName")});
 
     public IsNullFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isnumeric/IsNumericFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isnumeric/IsNumericFunDef.java
@@ -31,7 +31,7 @@ public class IsNumericFunDef  extends AbstractFunctionDefinition {
         evaluated as a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.LOGICAL, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.VALUE, "VarName" )});
+                    FunctionParameterR.param(DataType.VALUE, "VarName")});
 
     public IsNumericFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isobject/IsObjectFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/isobject/IsObjectFunDef.java
@@ -31,7 +31,7 @@ public class IsObjectFunDef  extends AbstractFunctionDefinition {
         an object variable.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.LOGICAL, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.VALUE, "VarName" )});
+                    FunctionParameterR.param(DataType.VALUE, "VarName")});
 
     public IsObjectFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/lcase/LCaseFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/lcase/LCaseFunDef.java
@@ -31,7 +31,7 @@ public class LCaseFunDef  extends AbstractFunctionDefinition {
         Returns a String that has been converted to lowercase.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.STRING, "String" )});
+                    FunctionParameterR.param(DataType.STRING, "String")});
 
     public LCaseFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/left/LeftFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/left/LeftFunDef.java
@@ -33,7 +33,7 @@ public class LeftFunDef  extends AbstractFunctionDefinition {
         string.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.STRING, "String" ), new FunctionParameterR( DataType.INTEGER, "Length" )});
+                    FunctionParameterR.param(DataType.STRING, "String"), FunctionParameterR.param(DataType.INTEGER, "Length")});
 
     public LeftFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/log/LogFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/log/LogFunDef.java
@@ -31,7 +31,7 @@ public class LogFunDef  extends AbstractFunctionDefinition {
         Returns a Double specifying the natural logarithm of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public LogFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ltrim/LTrimFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ltrim/LTrimFunDef.java
@@ -32,7 +32,7 @@ public class LTrimFunDef  extends AbstractFunctionDefinition {
         without leading spaces.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.STRING, "String" )});
+                    FunctionParameterR.param(DataType.STRING, "String")});
 
     public LTrimFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/mid/MidResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/mid/MidResolver.java
@@ -31,17 +31,14 @@ public class MidResolver extends AbstractFunctionDefinitionMultiResolver {
     private static String DESCRIPTION = """
         Returns a specified number of characters from a string.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.STRING, "Value"),
-            new FunctionParameterR(DataType.INTEGER, "Begin Index")};
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.STRING, "Value"),
-            new FunctionParameterR(DataType.INTEGER, "Begin Index"), new FunctionParameterR(DataType.INTEGER, "Length")};
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "Value"),
+            FunctionParameterR.param(DataType.INTEGER, "Begin Index"),
+            FunctionParameterR.param(DataType.INTEGER, "Length").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.STRING, p2);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.STRING, params);
 
     public MidResolver() {
-        super(List.of(new MidFunDef(functionMetaData1), new MidFunDef(functionMetaData2)));
+        super(List.of(new MidFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/minute/MinuteFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/minute/MinuteFunDef.java
@@ -31,7 +31,7 @@ public class MinuteFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Integer) specifying a whole number between 0 and
         59, inclusive, representing the minute of the hour.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public MinuteFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/mirr/MIRRFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/mirr/MIRRFunDef.java
@@ -32,9 +32,9 @@ public class MIRRFunDef  extends AbstractFunctionDefinition {
         a series of periodic cash flows (payments and receipts).""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.ARRAY, "ValueArray" ),
-                    new FunctionParameterR( DataType.NUMERIC, "FinanceRate" ),
-                    new FunctionParameterR( DataType.NUMERIC, "ReinvestRate" ) });
+                    FunctionParameterR.param(DataType.ARRAY, "ValueArray"),
+                    FunctionParameterR.param(DataType.NUMERIC, "FinanceRate"),
+                    FunctionParameterR.param(DataType.NUMERIC, "ReinvestRate") });
 
     public MIRRFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/month/MonthFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/month/MonthFunDef.java
@@ -31,7 +31,7 @@ public class MonthFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Integer) specifying a whole number between 1 and "
         + "12, inclusive, representing the month of the year.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public MonthFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/monthname/MonthNameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/monthname/MonthNameFunDef.java
@@ -32,7 +32,7 @@ public class MonthNameFunDef  extends AbstractFunctionDefinition {
         Returns a string indicating the specified month.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.INTEGER, "Month" ), new FunctionParameterR( DataType.LOGICAL, "Abbreviate" )});
+                    FunctionParameterR.param(DataType.INTEGER, "Month"), FunctionParameterR.param(DataType.LOGICAL, "Abbreviate")});
 
     public MonthNameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/nper/NPerFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/nper/NPerFunDef.java
@@ -33,11 +33,11 @@ public class NPerFunDef  extends AbstractFunctionDefinition {
         based on periodic, fixed payments and a fixed interest rate.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] { 
-                    new FunctionParameterR( DataType.NUMERIC, "Rate" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Pmt" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Pv" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Fv" ),
-                    new FunctionParameterR( DataType.LOGICAL, "Due" ) });
+                    FunctionParameterR.param(DataType.NUMERIC, "Rate"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Pmt"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Pv"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Fv"),
+                    FunctionParameterR.param(DataType.LOGICAL, "Due") });
 
     public NPerFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/npv/NPVFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/npv/NPVFunDef.java
@@ -33,8 +33,8 @@ public class NPVFunDef  extends AbstractFunctionDefinition {
         and a discount rate.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "R" ),
-                    new FunctionParameterR( DataType.ARRAY, "CFS" ) });
+                    FunctionParameterR.param(DataType.NUMERIC, "R"),
+                    FunctionParameterR.param(DataType.ARRAY, "CFS") });
 
     public NPVFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/oct/OctFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/oct/OctFunDef.java
@@ -29,7 +29,7 @@ public class OctFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns a Variant (String) representing the octal value of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "Number" ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "Number") });
 
     public OctFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/pmt/PmtFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/pmt/PmtFunDef.java
@@ -33,11 +33,11 @@ public class PmtFunDef  extends AbstractFunctionDefinition {
         periodic, fixed payments and a fixed interest rate.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] { 
-                    new FunctionParameterR( DataType.NUMERIC, "Rate" ),
-                    new FunctionParameterR( DataType.NUMERIC, "NPer" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Pv" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Fv" ),
-                    new FunctionParameterR( DataType.LOGICAL, "Due" ) });
+                    FunctionParameterR.param(DataType.NUMERIC, "Rate"),
+                    FunctionParameterR.param(DataType.NUMERIC, "NPer"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Pv"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Fv"),
+                    FunctionParameterR.param(DataType.LOGICAL, "Due") });
 
     public PmtFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ppmt/PPmtResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/ppmt/PPmtResolver.java
@@ -33,26 +33,16 @@ public class PPmtResolver extends AbstractFunctionDefinitionMultiResolver {
         of an annuity based on periodic, fixed payments and a fixed
         interest rate.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "Per"), new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pv") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "Per"), new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pv"), new FunctionParameterR(DataType.NUMERIC, "Fv") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.NUMERIC, "Rate"),
-            new FunctionParameterR(DataType.NUMERIC, "Per"), new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pv"), new FunctionParameterR(DataType.NUMERIC, "Fv"),
-            new FunctionParameterR(DataType.LOGICAL, "due") };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.NUMERIC, "Rate"),
+            FunctionParameterR.param(DataType.NUMERIC, "Per"), FunctionParameterR.param(DataType.NUMERIC, "NPer"),
+            FunctionParameterR.param(DataType.NUMERIC, "Pv"),
+            FunctionParameterR.param(DataType.NUMERIC, "Fv").asOptional(),
+            FunctionParameterR.param(DataType.LOGICAL, "due").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p3);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public PPmtResolver() {
-        super(List.of(new PPmtFunDef(functionMetaData1), new PPmtFunDef(functionMetaData2),
-                new PPmtFunDef(functionMetaData3)));
+        super(List.of(new PPmtFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/pv/PVFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/pv/PVFunDef.java
@@ -34,11 +34,11 @@ public class PVFunDef  extends AbstractFunctionDefinition {
         interest rate.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] { 
-                    new FunctionParameterR( DataType.NUMERIC, "Rate" ),
-                    new FunctionParameterR( DataType.NUMERIC, "NPer" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Pmt" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Fv" ),
-                    new FunctionParameterR( DataType.LOGICAL, "Due" ) });
+                    FunctionParameterR.param(DataType.NUMERIC, "Rate"),
+                    FunctionParameterR.param(DataType.NUMERIC, "NPer"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Pmt"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Fv"),
+                    FunctionParameterR.param(DataType.LOGICAL, "Due") });
 
     public PVFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/rate/RateResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/rate/RateResolver.java
@@ -32,30 +32,16 @@ public class RateResolver extends AbstractFunctionDefinitionMultiResolver {
         Returns a Double specifying the interest rate per period for an
         annuity.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pmt"), new FunctionParameterR(DataType.NUMERIC, "Pv")};
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pmt"), new FunctionParameterR(DataType.NUMERIC, "Pv"),
-            new FunctionParameterR(DataType.NUMERIC, "Fv")};
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pmt"), new FunctionParameterR(DataType.NUMERIC, "Pv"),
-            new FunctionParameterR(DataType.NUMERIC, "Fv"), new FunctionParameterR(DataType.LOGICAL, "Due")};
-    private static FunctionParameterR[] p4 = { new FunctionParameterR(DataType.NUMERIC, "NPer"),
-            new FunctionParameterR(DataType.NUMERIC, "Pmt"), new FunctionParameterR(DataType.NUMERIC, "Pv"),
-            new FunctionParameterR(DataType.NUMERIC, "Fv"), new FunctionParameterR(DataType.LOGICAL, "Due"),
-            new FunctionParameterR(DataType.NUMERIC, "Guess")};
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.NUMERIC, "NPer"),
+            FunctionParameterR.param(DataType.NUMERIC, "Pmt"), FunctionParameterR.param(DataType.NUMERIC, "Pv"),
+            FunctionParameterR.param(DataType.NUMERIC, "Fv").asOptional(),
+            FunctionParameterR.param(DataType.LOGICAL, "Due").asOptional(),
+            FunctionParameterR.param(DataType.NUMERIC, "Guess").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p3);
-    private static FunctionMetaData functionMetaData4 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p4);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public RateResolver() {
-        super(List.of(new RateFunDef(functionMetaData1), new RateFunDef(functionMetaData2),
-                new RateFunDef(functionMetaData3), new RateFunDef(functionMetaData4)));
+        super(List.of(new RateFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/replace/ReplaceResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/replace/ReplaceResolver.java
@@ -32,25 +32,16 @@ public class ReplaceResolver extends AbstractFunctionDefinitionMultiResolver {
         Returns a string in which a specified substring has been replaced
         with another substring a specified number of times.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.STRING, "expression"), new FunctionParameterR(DataType.STRING, "find"), new FunctionParameterR(DataType.STRING, "replace") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.STRING, "expression"), new FunctionParameterR(DataType.STRING, "find"), new FunctionParameterR(DataType.STRING, "replace"),
-            new FunctionParameterR(DataType.INTEGER, "start") };
-    private static FunctionParameterR[] p3 = { new FunctionParameterR(DataType.STRING, "expression"), new FunctionParameterR(DataType.STRING, "find"), new FunctionParameterR(DataType.STRING, "replace"),
-            new FunctionParameterR(DataType.INTEGER, "start"), new FunctionParameterR(DataType.INTEGER, "coun")};
-    private static FunctionParameterR[] p4 = { new FunctionParameterR(DataType.STRING, "expression"), new FunctionParameterR(DataType.STRING, "find"), new FunctionParameterR(DataType.STRING, "replace"),
-            new FunctionParameterR(DataType.INTEGER, "start"), new FunctionParameterR(DataType.INTEGER, "coun"), new FunctionParameterR(DataType.INTEGER, "compare") }; // compare is currently ignored
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "expression"),
+            FunctionParameterR.param(DataType.STRING, "find"), FunctionParameterR.param(DataType.STRING, "replace"),
+            FunctionParameterR.param(DataType.INTEGER, "start").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "coun").asOptional(),
+            FunctionParameterR.param(DataType.INTEGER, "compare").asOptional() }; // compare is currently ignored
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
-    private static FunctionMetaData functionMetaData3 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p3);
-    private static FunctionMetaData functionMetaData4 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p4);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public ReplaceResolver() {
-        super(List.of(new ReplaceFunDef(functionMetaData1), new ReplaceFunDef(functionMetaData2),
-                new ReplaceFunDef(functionMetaData3), new ReplaceFunDef(functionMetaData4)));
+        super(List.of(new ReplaceFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/right/RightFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/right/RightFunDef.java
@@ -33,8 +33,8 @@ public class RightFunDef  extends AbstractFunctionDefinition {
         characters from the right side of a string.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] { 
-                    new FunctionParameterR( DataType.STRING, "Sstring" ),
-                    new FunctionParameterR( DataType.INTEGER, "Length" ) });
+                    FunctionParameterR.param(DataType.STRING, "Sstring"),
+                    FunctionParameterR.param(DataType.INTEGER, "Length") });
 
     public RightFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/round/RoundResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/round/RoundResolver.java
@@ -31,15 +31,13 @@ public class RoundResolver extends AbstractFunctionDefinitionMultiResolver {
     private static String DESCRIPTION = """
         Returns a number rounded to a specified number of decimal places.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.NUMERIC, "Number") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.NUMERIC, "Number"), new FunctionParameterR(DataType.INTEGER, "Digits After Decimal")};
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.NUMERIC, "Number"),
+            FunctionParameterR.param(DataType.INTEGER, "Digits After Decimal").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public RoundResolver() {
-        super(List.of(new RoundFunDef(functionMetaData1), new RoundFunDef(functionMetaData2)));
+        super(List.of(new RoundFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/rtrim/RTrimFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/rtrim/RTrimFunDef.java
@@ -32,7 +32,7 @@ public class RTrimFunDef  extends AbstractFunctionDefinition {
         without trailing spaces.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.STRING, "String" )});
+                    FunctionParameterR.param(DataType.STRING, "String")});
 
     public RTrimFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/second/SecondFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/second/SecondFunDef.java
@@ -31,7 +31,7 @@ public class SecondFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Integer) specifying a whole number between 0 and
         59, inclusive, representing the second of the minute.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public SecondFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sgn/SgnFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sgn/SgnFunDef.java
@@ -31,7 +31,7 @@ public class SgnFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Integer) indicating the sign of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.INTEGER, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public SgnFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sin/SinFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sin/SinFunDef.java
@@ -31,7 +31,7 @@ public class SinFunDef  extends AbstractFunctionDefinition {
         Returns a Double specifying the sine of an angle.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public SinFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sln/SLNFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sln/SLNFunDef.java
@@ -32,9 +32,9 @@ public class SLNFunDef  extends AbstractFunctionDefinition {
         asset for a single period.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Cost" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Salvage" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Life" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Cost"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Salvage"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Life")});
 
     public SLNFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/space/SpaceFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/space/SpaceFunDef.java
@@ -32,7 +32,7 @@ public class SpaceFunDef  extends AbstractFunctionDefinition {
         spaces.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.INTEGER, "Number" ) });
+                    FunctionParameterR.param(DataType.INTEGER, "Number") });
 
     public SpaceFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sqr/SqrFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/sqr/SqrFunDef.java
@@ -31,7 +31,7 @@ public class SqrFunDef  extends AbstractFunctionDefinition {
         Returns a Double specifying the square root of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public SqrFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/str/StrFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/str/StrFunDef.java
@@ -29,7 +29,7 @@ public class StrFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns a Variant (String) representation of a number.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR( DataType.VALUE, "number" ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.VALUE, "number") });
 
     public StrFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/strcomp/StrCompResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/strcomp/StrCompResolver.java
@@ -32,16 +32,14 @@ public class StrCompResolver extends AbstractFunctionDefinitionMultiResolver {
         Returns a Variant (Integer) indicating the result of a string
         comparison.""";
 
-    private static FunctionParameterR[] p1 = { new FunctionParameterR(DataType.STRING, "String1"), new FunctionParameterR(DataType.STRING, "String2") };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR(DataType.STRING, "String1"), new FunctionParameterR(DataType.STRING, "String2"),
-            new FunctionParameterR(DataType.INTEGER, "Compare")  };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.STRING, "String1"),
+            FunctionParameterR.param(DataType.STRING, "String2"),
+            FunctionParameterR.param(DataType.INTEGER, "Compare").asOptional() };
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.INTEGER, p2);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.INTEGER, params);
 
     public StrCompResolver() {
-        super(List.of(new StrCompFunDef(functionMetaData1), new StrCompFunDef(functionMetaData2)));
+        super(List.of(new StrCompFunDef(functionMetaData)));
     }
 }

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/string/StringFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/string/StringFunDef.java
@@ -29,7 +29,7 @@ public class StringFunDef  extends AbstractFunctionDefinition {
     static FunctionOperationAtom atom = new FunctionOperationAtom("String");
     static String description = "";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR( DataType.INTEGER, "Number" ), new FunctionParameterR( DataType.STRING, "Character" ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.INTEGER, "Number"), FunctionParameterR.param(DataType.STRING, "Character") });
 
     public StringFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/strreverse/StrReverseFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/strreverse/StrReverseFunDef.java
@@ -31,7 +31,7 @@ public class StrReverseFunDef  extends AbstractFunctionDefinition {
         Returns a string in which the character order of a specified string
         is reversed.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "String" ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String") });
 
     public StrReverseFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/syd/SYDFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/syd/SYDFunDef.java
@@ -32,10 +32,10 @@ public class SYDFunDef  extends AbstractFunctionDefinition {
         an asset for a specified period.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Cost" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Salvage" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Life" ),
-                    new FunctionParameterR( DataType.NUMERIC, "Period" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Cost"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Salvage"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Life"),
+                    FunctionParameterR.param(DataType.NUMERIC, "Period")});
 
     public SYDFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/tan/TanFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/tan/TanFunDef.java
@@ -31,7 +31,7 @@ public class TanFunDef  extends AbstractFunctionDefinition {
         Returns a Double specifying the tangent of an angle.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.NUMERIC, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.NUMERIC, "Number" )});
+                    FunctionParameterR.param(DataType.NUMERIC, "Number")});
 
     public TanFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/timeserial/TimeSerialFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/timeserial/TimeSerialFunDef.java
@@ -31,8 +31,8 @@ public class TimeSerialFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Date) containing the time for a specific hour,
         minute, and second.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.DATE_TIME, new FunctionParameterR[] { new FunctionParameterR( DataType.INTEGER, "Hour" ),
-                    new FunctionParameterR( DataType.INTEGER, "Minute" ), new FunctionParameterR( DataType.INTEGER, "Second" ) });
+            DataType.DATE_TIME, new FunctionParameterR[] { FunctionParameterR.param(DataType.INTEGER, "Hour"),
+                    FunctionParameterR.param(DataType.INTEGER, "Minute"), FunctionParameterR.param(DataType.INTEGER, "Second") });
 
     public TimeSerialFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/timevalue/TimeValueFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/timevalue/TimeValueFunDef.java
@@ -30,7 +30,7 @@ public class TimeValueFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns a Variant (Date) containing the time.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.DATE_TIME, new FunctionParameterR[] { new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.DATE_TIME, new FunctionParameterR[] { FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public TimeValueFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/trim/TrimFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/trim/TrimFunDef.java
@@ -31,7 +31,7 @@ public class TrimFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (String) containing a copy of a specified string
         without leading and trailing spaces.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "String" ) });
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String") });
 
     public TrimFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/typename/TypeNameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/typename/TypeNameFunDef.java
@@ -30,7 +30,7 @@ public class TypeNameFunDef  extends AbstractFunctionDefinition {
         Returns a String that provides information about a variable.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
             DataType.STRING, new FunctionParameterR[] {
-                    new FunctionParameterR( DataType.VALUE, "VarName" )});
+                    FunctionParameterR.param(DataType.VALUE, "VarName")});
 
     public TypeNameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/val/ValFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/val/ValFunDef.java
@@ -29,7 +29,7 @@ public class ValFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns an expression that has been converted to a Variant of subtype Double.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.NUMERIC, new FunctionParameterR[] { new FunctionParameterR( DataType.STRING, "String" ) });
+            DataType.NUMERIC, new FunctionParameterR[] { FunctionParameterR.param(DataType.STRING, "String") });
 
     public ValFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/weekday/WeekdayResolver.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/weekday/WeekdayResolver.java
@@ -31,17 +31,13 @@ public class WeekdayResolver extends AbstractFunctionDefinitionMultiResolver {
     private static String DESCRIPTION = """
         Returns a Variant (Integer) containing a whole number representing
         the day of the week.""";
-    private static FunctionParameterR[] p1 = { new FunctionParameterR( DataType.DATE_TIME, "Date" ) };
-    private static FunctionParameterR[] p2 = { new FunctionParameterR( DataType.DATE_TIME, "Date" ),
-            new FunctionParameterR( DataType.INTEGER, "First Day Of Week" ) };
+    private static FunctionParameterR[] params = { FunctionParameterR.param(DataType.DATE_TIME, "Date"),
+            FunctionParameterR.param(DataType.INTEGER, "First Day Of Week").asOptional() };
 
-
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p1);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.NUMERIC, p2);
+    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
+            DataType.NUMERIC, params);
 
     public WeekdayResolver() {
-        super(List.of(new WeekdayFunDef(functionMetaData1), new WeekdayFunDef(functionMetaData2)));
+        super(List.of(new WeekdayFunDef(functionMetaData)));
     }
 }    

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/weekdayname/WeekdayNameFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/weekdayname/WeekdayNameFunDef.java
@@ -31,8 +31,8 @@ public class WeekdayNameFunDef  extends AbstractFunctionDefinition {
     static String description = """
         Returns a string indicating the specified day of the week.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.STRING, new FunctionParameterR[] { new FunctionParameterR( DataType.INTEGER, "Weekday" ),
-                    new FunctionParameterR( DataType.LOGICAL, "abbreviate" ), new FunctionParameterR( DataType.INTEGER, "First day of week" )});
+            DataType.STRING, new FunctionParameterR[] { FunctionParameterR.param(DataType.INTEGER, "Weekday"),
+                    FunctionParameterR.param(DataType.LOGICAL, "abbreviate"), FunctionParameterR.param(DataType.INTEGER, "First day of week")});
 
     public WeekdayNameFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/year/YearFunDef.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/function/def/vba/year/YearFunDef.java
@@ -31,7 +31,7 @@ public class YearFunDef  extends AbstractFunctionDefinition {
         Returns a Variant (Integer) containing a whole number representing
         the year.""";
     static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, description,
-            DataType.INTEGER, new FunctionParameterR[] { new FunctionParameterR( DataType.DATE_TIME, "Date" ) });
+            DataType.INTEGER, new FunctionParameterR[] { FunctionParameterR.param(DataType.DATE_TIME, "Date") });
 
     public YearFunDef() {
         super(functionMetaData);

--- a/common/src/main/java/org/eclipse/daanse/olap/query/base/Expressions.java
+++ b/common/src/main/java/org/eclipse/daanse/olap/query/base/Expressions.java
@@ -49,4 +49,33 @@ public class Expressions {
         return Stream.of(expressions).map(e -> new FunctionParameterR(e.getCategory())).toArray(FunctionParameterR[]::new);
     }
 
+    /**
+     * Per-call parameters: the declared parameter each argument was bound to,
+     * keeping name/description/flags, with the data type replaced by the actual
+     * expression category. Falls back to bare category parameters when no
+     * binding is available for an argument.
+     */
+    public static FunctionParameterR[] boundParametersOf(Expression[] expressions,
+            org.eclipse.daanse.olap.api.function.FunctionMetaData matched,
+            java.util.List<org.eclipse.daanse.olap.api.function.ArgumentBinding> bindings) {
+        FunctionParameterR[] result = new FunctionParameterR[expressions.length];
+        org.eclipse.daanse.olap.api.function.FunctionParameter[] declared = matched.parameters();
+        for (org.eclipse.daanse.olap.api.function.ArgumentBinding binding : bindings) {
+            int argIndex = binding.argumentIndex();
+            if (argIndex < 0 || argIndex >= result.length) {
+                continue;
+            }
+            org.eclipse.daanse.olap.api.function.FunctionParameter parameter = declared[binding.parameterIndex()];
+            result[argIndex] = new FunctionParameterR(expressions[argIndex].getCategory(), parameter.name(),
+                    parameter.description(), parameter.reservedWords(), parameter.optional(), parameter.repeatable(),
+                    parameter.repeatGroup(), parameter.skippable());
+        }
+        for (int i = 0; i < result.length; i++) {
+            if (result[i] == null) {
+                result[i] = new FunctionParameterR(expressions[i].getCategory());
+            }
+        }
+        return result;
+    }
+
 }

--- a/common/src/main/resources/org/eclipse/daanse/olap/function/core/text/functions_de.properties
+++ b/common/src/main/resources/org/eclipse/daanse/olap/function/core/text/functions_de.properties
@@ -1,0 +1,59 @@
+# Deutsche Funktionstexte fuer MDSCHEMA_FUNCTIONS (Discover) und Formel-Editoren.
+# Schluesselschema: <textKey>.description|caption|example|remarks
+#                   <textKey>.param.<Parametername>.displayName|description
+
+Sum.description=Liefert die Summe eines numerischen Ausdrucks über eine Menge.
+Sum.caption=Summe
+Sum.example=Sum({[Product].Members}, [Measures].[Sales])
+Sum.param.Set.description=Die Menge, über die aggregiert wird.
+Sum.param.Numeric_Expression.displayName=Numerischer Ausdruck
+Sum.param.Numeric_Expression.description=Je Element ausgewerteter numerischer Ausdruck.
+
+Avg.description=Liefert den Mittelwert eines numerischen Ausdrucks über eine Menge.
+Avg.caption=Mittelwert
+
+Count.description=Zählt die Elemente einer Menge.
+Count.caption=Anzahl
+Count.param.Empty_Flag.description=INCLUDEEMPTY (Standard) zählt leere Zellen mit, EXCLUDEEMPTY nicht.
+
+Min.caption=Minimum
+Max.caption=Maximum
+Median.caption=Median
+
+Order.description=Sortiert die Elemente einer Menge, wahlweise unter Erhalt oder Bruch der Hierarchie.
+Order.caption=Sortieren
+Order.param.Sort_Flag.displayName=Sortierkennzeichen
+Order.param.Sort_Flag.description=ASC (Standard), DESC, BASC oder BDESC — B-Varianten brechen die Hierarchie.
+
+Filter.description=Liefert die Elemente einer Menge, die eine Bedingung erfüllen.
+Filter.caption=Filtern
+
+Crossjoin.description=Bildet das Kreuzprodukt zweier oder mehrerer Mengen.
+Crossjoin.caption=Kreuzprodukt
+
+Head.description=Liefert die ersten Elemente einer Menge.
+Head.caption=Anfang
+Tail.description=Liefert die letzten Elemente einer Menge.
+Tail.caption=Ende
+
+Union.caption=Vereinigung
+Union.param.ALL.description=ALL behält Duplikate; DISTINCT (Standard) entfernt sie.
+Except.caption=Differenz
+Intersect.caption=Schnittmenge
+
+Descendants.description=Liefert die Nachkommen eines Elements relativ zu einer Ebene oder Tiefe.
+Descendants.caption=Nachkommen
+Children.caption=Kinder
+Parent.caption=Elternelement
+Ancestor.caption=Vorfahr
+
+Ytd.caption=Jahr bis Datum
+Qtd.caption=Quartal bis Datum
+Mtd.caption=Monat bis Datum
+Wtd.caption=Woche bis Datum
+PeriodsToDate.caption=Perioden bis Datum
+ParallelPeriod.caption=Parallelperiode
+
+IIf.description=Liefert je nach Bedingung den ersten oder zweiten Wert.
+IIf.caption=Wenn-Dann
+CoalesceEmpty.description=Liefert den ersten nicht-leeren Wert der Argumentliste.

--- a/common/src/test/java/org/eclipse/daanse/olap/function/core/FunctionServiceImplTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/core/FunctionServiceImplTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.function.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
+import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FunctionServiceImplTest {
+
+    private FunctionServiceImpl functionService;
+    private FunctionResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        functionService = new FunctionServiceImpl();
+
+        FunctionOperationAtom atom = new FunctionOperationAtom("TestFun");
+        FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, "test function", DataType.NUMERIC,
+                new FunctionParameterR[] { new FunctionParameterR(DataType.SET) });
+
+        resolver = mock(FunctionResolver.class);
+        when(resolver.getFunctionAtom()).thenReturn(atom);
+        when(resolver.getRepresentativeFunctionMetaDatas()).thenReturn(List.of(functionMetaData));
+        when(resolver.getReservedWords()).thenReturn(List.of("TESTWORD"));
+    }
+
+    @Test
+    void addResolverRegistersResolverAndMetaData() {
+        functionService.addResolver(resolver);
+
+        assertThat(functionService.getResolvers()).containsExactly(resolver);
+        assertThat(functionService.getResolvers(resolver.getFunctionAtom())).containsExactly(resolver);
+        assertThat(functionService.getFunctionMetaDatas()).hasSize(1);
+        assertThat(functionService.isReservedWord("testword")).isTrue();
+    }
+
+    @Test
+    void removeResolverDeregistersResolver() {
+        functionService.addResolver(resolver);
+
+        functionService.removeResolver(resolver);
+
+        assertThat(functionService.getResolvers()).isEmpty();
+        assertThat(functionService.getResolvers(resolver.getFunctionAtom())).isEmpty();
+        assertThat(functionService.getFunctionMetaDatas()).isEmpty();
+        assertThat(functionService.isReservedWord("testword")).isFalse();
+    }
+
+    @Test
+    void removeResolverIsIdempotentAndKeepsOthers() {
+        functionService.addResolver(resolver);
+        functionService.removeResolver(resolver);
+        functionService.removeResolver(resolver);
+
+        assertThat(functionService.getResolvers()).isEmpty();
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/function/core/integration/FunctionMetaDataExportTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/core/integration/FunctionMetaDataExportTest.java
@@ -581,14 +581,14 @@ class FunctionMetaDataExportTest {
             if (p.description != null && !p.description.isBlank()) {
                 sb.append(p.description);
             } else {
-                sb.append("A ").append(p.dataType.getPrittyName()).append(" expression");
+                sb.append("A ").append(p.dataType.getPrettyName()).append(" expression");
                 if (p.optional)
                     sb.append(" (optional)");
             }
             sb.append(".\n");
         }
 
-        sb.append("#' @return MDX string returning ").append(g.returnType.getPrittyName()).append(".\n");
+        sb.append("#' @return MDX string returning ").append(g.returnType.getPrettyName()).append(".\n");
         sb.append("#' @family ").append(category).append("\n");
         sb.append("#' @export\n");
     }

--- a/common/src/test/java/org/eclipse/daanse/olap/function/core/text/FunctionTextServiceImplTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/core/text/FunctionTextServiceImplTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.function.core.text;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+
+import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
+import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.ResolvedFunctionTexts;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.junit.jupiter.api.Test;
+
+class FunctionTextServiceImplTest {
+
+    private static FunctionMetaData sum() {
+        return FunctionMetaDataR.of(new FunctionOperationAtom("Sum"),
+                "Returns the sum of a numeric expression evaluated over a set.", DataType.NUMERIC,
+                FunctionParameterR.param(DataType.SET),
+                FunctionParameterR.param(DataType.NUMERIC).asOptional());
+    }
+
+    @Test
+    void withoutProvidersServesInlineTexts() {
+        FunctionTextServiceImpl service = new FunctionTextServiceImpl();
+
+        ResolvedFunctionTexts texts = service.resolve(sum(), Locale.of("de", "DE"));
+
+        assertThat(texts.description()).startsWith("Returns the sum");
+        assertThat(texts.caption()).isEqualTo("Sum");
+        assertThat(texts.parameters().get("Numeric_Expression").displayName()).isEqualTo("Numeric Expression");
+    }
+
+    @Test
+    void bundledGermanTextsResolveWithFallbackChain() {
+        FunctionTextServiceImpl service = new FunctionTextServiceImpl();
+        service.addProvider(new BundledFunctionTextProvider());
+
+        ResolvedFunctionTexts texts = service.resolve(sum(), Locale.of("de", "DE"));
+
+        assertThat(texts.description()).contains("Summe eines numerischen Ausdrucks");
+        assertThat(texts.caption()).isEqualTo("Summe");
+        assertThat(texts.example()).contains("Sum({[Product].Members}, [Measures].[Sales])");
+        assertThat(texts.parameters().get("Numeric_Expression").displayName()).isEqualTo("Numerischer Ausdruck");
+        assertThat(texts.parameters().get("Set").description())
+                .hasValueSatisfying(v -> assertThat(v).contains("aggregiert"));
+    }
+
+    @Test
+    void unknownLocaleFallsBackToInline() {
+        FunctionTextServiceImpl service = new FunctionTextServiceImpl();
+        service.addProvider(new BundledFunctionTextProvider());
+
+        ResolvedFunctionTexts texts = service.resolve(sum(), Locale.of("fr", "FR"));
+
+        assertThat(texts.description()).startsWith("Returns the sum");
+    }
+}

--- a/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/space/SpaceResolverTest.java
+++ b/common/src/test/java/org/eclipse/daanse/olap/function/def/vba/space/SpaceResolverTest.java
@@ -14,23 +14,20 @@
 package org.eclipse.daanse.olap.function.def.vba.space;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.daanse.olap.api.DataType;
-import org.eclipse.daanse.olap.api.function.FunctionDefinition;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
-import org.eclipse.daanse.olap.api.function.FunctionResolver.Conversion;
+import org.eclipse.daanse.olap.api.function.FunctionResolutionResult;
 import org.eclipse.daanse.olap.api.query.Validator;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class SpaceResolverTest {
@@ -48,13 +45,33 @@ class SpaceResolverTest {
 
     @Test
     void shouldResolveWithValidIntegerArgument() {
-        List<Conversion> conversions = List.of();
-        when(validator.canConvert(anyInt(), eq(expression), any(), eq(conversions))).thenReturn(true);
+        when(validator.canConvert(anyInt(), eq(expression), any(), any())).thenReturn(true);
 
         Expression[] args = { expression };
-        FunctionDefinition result = spaceResolver.resolve(args, validator, conversions);
+        Optional<FunctionResolutionResult> result = spaceResolver.resolve(args, validator);
 
-        assertThat(result).isInstanceOf(SpaceFunDef.class);
+        assertThat(result).isPresent();
+        assertThat(result.get().definition()).isInstanceOf(SpaceFunDef.class);
+        assertThat(result.get().matchedMetaData()).isNotNull();
+        assertThat(result.get().bindings()).hasSize(1);
+    }
+
+    @Test
+    void shouldNotResolveWhenValidatorCannotConvert() {
+        when(validator.canConvert(anyInt(), eq(expression), any(), any())).thenReturn(false);
+
+        Expression[] args = { expression };
+        Optional<FunctionResolutionResult> result = spaceResolver.resolve(args, validator);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotResolveWithWrongArgumentCount() {
+        when(validator.canConvert(anyInt(), any(Expression.class), any(), any())).thenReturn(true);
+
+        assertThat(spaceResolver.resolve(new Expression[] {}, validator)).isEmpty();
+        assertThat(spaceResolver.resolve(new Expression[] { expression, expression }, validator)).isEmpty();
     }
 
     @Test
@@ -84,36 +101,6 @@ class SpaceResolverTest {
         DataType parameterType = metaData.parameters()[0].dataType();
 
         assertThat(parameterType).isEqualTo(DataType.INTEGER);
-    }
-
-    @Test
-    @Disabled
-    void shouldFailWithNoArguments() {
-        List<Conversion> conversions = List.of();
-        Expression[] args = {};
-
-        assertThatExceptionOfType(Exception.class).isThrownBy(() -> spaceResolver.resolve(args, validator, conversions));
-    }
-
-    @Test
-    @Disabled
-    void shouldFailWithTooManyArguments() {
-        List<Conversion> conversions = List.of();
-        Expression[] args = { expression, expression };
-        when(validator.canConvert(anyInt(), any(Expression.class), any(), eq(conversions))).thenReturn(true);
-
-        assertThatExceptionOfType(Exception.class).isThrownBy(() -> spaceResolver.resolve(args, validator, conversions));
-    }
-
-    @Test
-    @Disabled
-    void shouldFailWhenValidatorCannotConvert() {
-        List<Conversion> conversions = List.of();
-        when(validator.canConvert(anyInt(), eq(expression), any(), eq(conversions))).thenReturn(false);
-
-        Expression[] args = { expression };
-
-        assertThatExceptionOfType(Exception.class).isThrownBy(() -> spaceResolver.resolve(args, validator, conversions));
     }
 
     @Test

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/MDSchemaDiscoverService.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/MDSchemaDiscoverService.java
@@ -81,10 +81,17 @@ public class MDSchemaDiscoverService {
     protected static final Logger LOGGER = LoggerFactory.getLogger(MDSchemaDiscoverService.class);
     private ContextListSupplyer contextsListSupplyer;
     private ActionService actionService;
+    private org.eclipse.daanse.olap.api.function.FunctionTextService functionTextService =
+            new org.eclipse.daanse.olap.function.core.text.FunctionTextServiceImpl();
 
     public MDSchemaDiscoverService(ContextListSupplyer contextsListSupplyer, ActionService actionService) {
         this.contextsListSupplyer = contextsListSupplyer;
         this.actionService = actionService;
+    }
+
+    /** Injects a localized text source; without one the inline (English) texts are served. */
+    public void setFunctionTextService(org.eclipse.daanse.olap.api.function.FunctionTextService functionTextService) {
+        this.functionTextService = functionTextService;
     }
 
     public List<MdSchemaActionsResponseRow> mdSchemaActions(MdSchemaActionsRequest request, RequestMetaData metaData) {
@@ -194,12 +201,15 @@ public class MDSchemaDiscoverService {
 
     public List<MdSchemaFunctionsResponseRow> mdSchemaFunctions(MdSchemaFunctionsRequest request,
             RequestMetaData metaData) {
-        Optional<String> oLibraryName = request.restrictions().libraryName();
-        Optional<InterfaceNameEnum> oInterfaceName = request.restrictions().interfaceName();
-        Optional<OriginEnum> oOrigin = request.restrictions().origin();
-        return contextsListSupplyer.getContexts().stream().map(c -> Utils.getMdSchemaFunctionsResponseRow(c,
-                oLibraryName, oInterfaceName, oOrigin, metaData)).flatMap(Collection::stream).toList();
-
+        // The function catalog is context independent — use the first context and
+        // emit every function exactly once.
+        List<org.eclipse.daanse.olap.api.Context<?>> contexts = contextsListSupplyer.getContexts();
+        if (contexts.isEmpty()) {
+            return List.of();
+        }
+        java.util.Locale locale = MdSchemaFunctionsRowMapper.localeOf(request.properties().localeIdentifier());
+        return MdSchemaFunctionsRowMapper.rows(contexts.get(0).getFunctionService(), functionTextService, locale,
+                request.restrictions());
     }
 
     public List<MdSchemaHierarchiesResponseRow> mdSchemaHierarchies(MdSchemaHierarchiesRequest request,

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/MdSchemaFunctionsRowMapper.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/MdSchemaFunctionsRowMapper.java
@@ -1,0 +1,217 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.olap.xmla.bridge.discover;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.daanse.mdx.model.api.expression.operation.EmptyOperationAtom;
+import org.eclipse.daanse.mdx.model.api.expression.operation.InternalOperationAtom;
+import org.eclipse.daanse.mdx.model.api.expression.operation.ParenthesesOperationAtom;
+import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionParameter;
+import org.eclipse.daanse.olap.api.function.FunctionService;
+import org.eclipse.daanse.olap.api.function.FunctionTextService;
+import org.eclipse.daanse.olap.api.function.ResolvedFunctionTexts;
+import org.eclipse.daanse.xmla.api.common.enums.InterfaceNameEnum;
+import org.eclipse.daanse.xmla.api.common.enums.OriginEnum;
+import org.eclipse.daanse.xmla.api.discover.mdschema.functions.MdSchemaFunctionsResponseRow;
+import org.eclipse.daanse.xmla.api.discover.mdschema.functions.MdSchemaFunctionsRestrictions;
+import org.eclipse.daanse.xmla.api.discover.mdschema.functions.ParameterInfo;
+import org.eclipse.daanse.xmla.model.record.discover.ParameterInfoR;
+import org.eclipse.daanse.xmla.model.record.discover.mdschema.functions.MdSchemaFunctionsResponseRowR;
+
+/**
+ * Maps the function metadata of a {@link FunctionService} onto the
+ * MDSCHEMA_FUNCTIONS rowset per [MS-SSAS], including the nested PARAMETERINFO
+ * rowset and localized display texts.
+ */
+public final class MdSchemaFunctionsRowMapper {
+
+    /** LCID → Locale for the common XMLA LocaleIdentifier values. */
+    private static final Map<Integer, Locale> LCIDS = Map.ofEntries(
+            Map.entry(1033, Locale.of("en", "US")), Map.entry(2057, Locale.of("en", "GB")),
+            Map.entry(1031, Locale.of("de", "DE")), Map.entry(1036, Locale.of("fr", "FR")),
+            Map.entry(1049, Locale.of("ru", "RU")), Map.entry(1034, Locale.of("es", "ES")),
+            Map.entry(3082, Locale.of("es", "ES")), Map.entry(1040, Locale.of("it", "IT")),
+            Map.entry(1041, Locale.of("ja", "JP")), Map.entry(1046, Locale.of("pt", "BR")),
+            Map.entry(2052, Locale.of("zh", "CN")), Map.entry(1043, Locale.of("nl", "NL")),
+            Map.entry(1045, Locale.of("pl", "PL")), Map.entry(1029, Locale.of("cs", "CZ")),
+            Map.entry(1035, Locale.of("fi", "FI")), Map.entry(1053, Locale.of("sv", "SE")),
+            Map.entry(1030, Locale.of("da", "DK")), Map.entry(1038, Locale.of("hu", "HU")),
+            Map.entry(1055, Locale.of("tr", "TR")));
+
+    private MdSchemaFunctionsRowMapper() {
+    }
+
+    public static Locale localeOf(Optional<Integer> localeIdentifier) {
+        return localeIdentifier.map(LCIDS::get).orElse(Locale.ENGLISH);
+    }
+
+    public static List<MdSchemaFunctionsResponseRow> rows(FunctionService functionService,
+            FunctionTextService textService, Locale locale, MdSchemaFunctionsRestrictions restrictions) {
+        List<MdSchemaFunctionsResponseRow> result = new ArrayList<>();
+        for (FunctionMetaData fm : functionService.getFunctionMetaDatas()) {
+            if (fm.operationAtom() instanceof EmptyOperationAtom
+                    || fm.operationAtom() instanceof InternalOperationAtom
+                    || fm.operationAtom() instanceof ParenthesesOperationAtom) {
+                continue;
+            }
+            if (!matches(fm, restrictions)) {
+                continue;
+            }
+            result.add(toRow(fm, textService.resolve(fm, locale)));
+        }
+        return result;
+    }
+
+    private static boolean matches(FunctionMetaData fm, MdSchemaFunctionsRestrictions restrictions) {
+        if (restrictions == null) {
+            return true;
+        }
+        if (restrictions.functionName().isPresent()
+                && !restrictions.functionName().get().equalsIgnoreCase(fm.operationAtom().name())) {
+            return false;
+        }
+        if (restrictions.origin().isPresent()
+                && restrictions.origin().get().getValue() != fm.origin().getValue()) {
+            return false;
+        }
+        if (restrictions.interfaceName().isPresent()
+                && !restrictions.interfaceName().get().name().equalsIgnoreCase(fm.functionInterface().name())) {
+            return false;
+        }
+        if (restrictions.libraryName().isPresent()
+                && !Optional.of(restrictions.libraryName().get()).equals(fm.libraryName())) {
+            return false;
+        }
+        return true;
+    }
+
+    private static MdSchemaFunctionsResponseRow toRow(FunctionMetaData fm, ResolvedFunctionTexts texts) {
+        String description = texts.description();
+        if (description != null) {
+            description = description.replace("\r", "");
+        }
+        FunctionParameter[] parameters = fm.parameters();
+
+        return new MdSchemaFunctionsResponseRowR(//
+                Optional.ofNullable(fm.operationAtom().name()), //
+                Optional.ofNullable(description), //
+                parameterList(parameters, texts), //
+                Optional.of(oleDbTypeOf(fm.returnCategory())), //
+                Optional.of(originOf(fm)), //
+                Optional.of(interfaceNameOf(fm)), //
+                fm.libraryName(), //
+                Optional.empty(), // DLL_NAME (unused per spec)
+                Optional.empty(), // HELP_FILE (unused per spec)
+                Optional.empty(), // HELP_CONTEXT (unused per spec)
+                fm.callingObject().map(DataType::getPrettyName), //
+                Optional.ofNullable(texts.caption()), //
+                parameterInfo(parameters, texts), //
+                Optional.empty(), // DIRECTQUERY_PUSHABLE (not declared by olap functions yet)
+                fm.visualCalculationsInfo() == 0 ? Optional.empty() : Optional.of(fm.visualCalculationsInfo()));
+    }
+
+    /** Chevron style per SSAS convention: «Set», [«Numeric Expression»]; repeat groups get an ellipsis. */
+    private static String parameterList(FunctionParameter[] parameters, ResolvedFunctionTexts texts) {
+        if (parameters == null || parameters.length == 0) {
+            return "(none)";
+        }
+        StringBuilder buf = new StringBuilder(64);
+        boolean repeated = false;
+        for (int i = 0; i < parameters.length; i++) {
+            FunctionParameter parameter = parameters[i];
+            if (i > 0) {
+                buf.append(", ");
+            }
+            String display = displayNameOf(parameter, texts);
+            boolean opt = parameter.optional() || parameter.skippable();
+            if (opt) {
+                buf.append('[');
+            }
+            buf.append('«').append(display).append('»');
+            if (opt) {
+                buf.append(']');
+            }
+            repeated |= parameter.repeatable();
+        }
+        if (repeated) {
+            buf.append('…');
+        }
+        return buf.toString();
+    }
+
+    private static Optional<List<ParameterInfo>> parameterInfo(FunctionParameter[] parameters,
+            ResolvedFunctionTexts texts) {
+        if (parameters == null || parameters.length == 0) {
+            return Optional.empty();
+        }
+        List<ParameterInfo> infos = new ArrayList<>(parameters.length);
+        for (FunctionParameter parameter : parameters) {
+            String name = parameter.name().orElseGet(() -> parameter.dataType().getPrettyName());
+            String parameterDescription = Optional
+                    .ofNullable(texts.parameters().get(parameter.name().orElse(null)))
+                    .flatMap(ResolvedFunctionTexts.ResolvedParameterTexts::description)
+                    .or(parameter::description).orElse("");
+            infos.add(new ParameterInfoR(name.replace('_', ' '), parameterDescription, parameter.optional(),
+                    parameter.repeatable(), parameter.repeatGroup(), parameter.skippable()));
+        }
+        return Optional.of(infos);
+    }
+
+    private static String displayNameOf(FunctionParameter parameter, ResolvedFunctionTexts texts) {
+        Optional<String> localized = Optional.ofNullable(texts.parameters().get(parameter.name().orElse(null)))
+                .map(ResolvedFunctionTexts.ResolvedParameterTexts::displayName);
+        return localized.orElseGet(() -> parameter.name().orElse(parameter.dataType().getPrettyName()))
+                .replace('_', ' ');
+    }
+
+    private static OriginEnum originOf(FunctionMetaData fm) {
+        return switch (fm.origin()) {
+        case MSOLAP -> OriginEnum.MSOLAP;
+        case UDF -> OriginEnum.UDF;
+        case RELATIONAL -> OriginEnum.RELATIONAL;
+        case SCALAR -> OriginEnum.SCALAR;
+        };
+    }
+
+    private static InterfaceNameEnum interfaceNameOf(FunctionMetaData fm) {
+        try {
+            return InterfaceNameEnum.valueOf(fm.functionInterface().name());
+        } catch (IllegalArgumentException e) {
+            return InterfaceNameEnum.OTHER;
+        }
+    }
+
+    /** OLE DB DBTYPE codes per [MS-SSAS] RETURN_TYPE ("The OLE DB data type"). */
+    static int oleDbTypeOf(DataType returnCategory) {
+        if (returnCategory == null) {
+            return 12; // DBTYPE_VARIANT
+        }
+        return switch (returnCategory) {
+        case INTEGER -> 3; // DBTYPE_I4
+        case NUMERIC -> 5; // DBTYPE_R8
+        case LOGICAL -> 11; // DBTYPE_BOOL
+        case STRING, SYMBOL -> 130; // DBTYPE_WSTR
+        case DATE_TIME -> 7; // DBTYPE_DATE
+        case EMPTY -> 0; // DBTYPE_EMPTY
+        default -> 12; // DBTYPE_VARIANT (set, tuple, member, level, hierarchy, dimension, cube, value, ...)
+        };
+    }
+}

--- a/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/Utils.java
+++ b/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/Utils.java
@@ -282,56 +282,6 @@ public class Utils {
         return getMdSchemaCubesResponseRow(connection, catalog, cubeName, baseCubeName, cubeSource);
     }
 
-    static List<MdSchemaFunctionsResponseRow> getMdSchemaFunctionsResponseRow(Context c, Optional<String> oLibraryName,
-            Optional<InterfaceNameEnum> oInterfaceName, Optional<OriginEnum> oOrigin, RequestMetaData metaData) {
-        List<MdSchemaFunctionsResponseRow> result = new ArrayList<>();
-        List<FunctionMetaData> fmList = c.getFunctionService().getFunctionMetaDatas();
-        StringBuilder buf = new StringBuilder(50);
-        for (FunctionMetaData fm : fmList) {
-            if (fm.operationAtom() instanceof EmptyOperationAtom//
-                    || fm.operationAtom() instanceof InternalOperationAtom//
-                    || fm.operationAtom() instanceof ParenthesesOperationAtom//
-            ) {
-                continue;
-            }
-
-            DataType[] paramCategories = fm.parameterDataTypes();
-            DataType returnCategory = fm.returnCategory();
-
-            // Convert Windows newlines in 'description' to UNIX format.
-            String description = fm.description();
-            if (description != null) {
-                description = fm.description().replace("\r", "");
-            }
-            if ((paramCategories == null) || (paramCategories.length == 0)) {
-                result.add(new MdSchemaFunctionsResponseRowR(Optional.ofNullable(fm.operationAtom().name()),
-                        Optional.ofNullable(description), "(none)", Optional.of(1), Optional.of(OriginEnum.MSOLAP),
-                        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                        Optional.empty(), Optional.ofNullable(fm.operationAtom().name()), Optional.empty(),
-                        Optional.empty(), Optional.empty()));
-            } else {
-
-                buf.setLength(0);
-                for (int j = 0; j < paramCategories.length; j++) {
-                    DataType v = paramCategories[j];
-                    if (j > 0) {
-                        buf.append(", ");
-                    }
-                    buf.append(v.getPrittyName());
-                }
-
-                VarType varType = VarType.forCategory(returnCategory.getName());
-                result.add(new MdSchemaFunctionsResponseRowR(Optional.ofNullable(fm.operationAtom().name()),
-                        Optional.ofNullable(description), buf.toString(), Optional.of(varType.ordinal()),
-                        Optional.of(OriginEnum.MSOLAP), Optional.empty(), Optional.empty(), Optional.empty(),
-                        Optional.empty(), Optional.empty(), Optional.empty(),
-                        Optional.ofNullable(fm.operationAtom().name()), Optional.empty(), Optional.empty(),
-                        Optional.empty()));
-            }
-        }
-        return result;
-    }
-
     private static List<MdSchemaCubesResponseRow> getMdSchemaCubesResponseRow(Connection connection, Catalog catalog,
             Optional<String> cubeName, Optional<String> baseCubeName, Optional<CubeSourceEnum> oCubeSource) {
         if (oCubeSource.isEmpty()) {

--- a/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/MDSchemaDiscoverServiceTest.java
+++ b/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/MDSchemaDiscoverServiceTest.java
@@ -308,34 +308,40 @@ class MDSchemaDiscoverServiceTest {
 
         MdSchemaFunctionsRequest request = mock(MdSchemaFunctionsRequest.class);
         MdSchemaFunctionsRestrictions restrictions = mock(MdSchemaFunctionsRestrictions.class);
+        Properties properties = mock(Properties.class);
         FunctionService functionService = mock(FunctionService.class);
         OperationAtom functionAtom1 = new FunctionOperationAtom("functionAtom1Name");
         OperationAtom functionAtom2 = new MethodOperationAtom("functionAtom2Name");
-        FunctionMetaData functionMetaData1 = mock(FunctionMetaData.class);
-        FunctionMetaData functionMetaData2 = mock(FunctionMetaData.class);
-        when(functionMetaData1.parameterDataTypes())
-                .thenAnswer(setupDummyArrayAnswer(DataType.INTEGER, DataType.MEMBER));
-        when(functionMetaData1.returnCategory()).thenReturn(DataType.INTEGER);
-        when(functionMetaData1.description()).thenReturn("functionMetaData1Description");
-        when(functionMetaData2.parameterDataTypes()).thenAnswer(setupDummyArrayAnswer(DataType.CUBE));
-        when(functionMetaData2.returnCategory()).thenReturn(DataType.MEMBER);
-        when(functionMetaData2.description()).thenReturn("functionMetaData2Description");
-
-        when(functionMetaData1.operationAtom()).thenReturn(functionAtom1);
-        when(functionMetaData2.operationAtom()).thenReturn(functionAtom2);
+        FunctionMetaData functionMetaData1 = org.eclipse.daanse.olap.function.core.FunctionMetaDataR.of(
+                (FunctionOperationAtom) functionAtom1, "functionMetaData1Description", DataType.INTEGER,
+                org.eclipse.daanse.olap.function.core.FunctionParameterR.param(DataType.INTEGER),
+                org.eclipse.daanse.olap.function.core.FunctionParameterR.param(DataType.MEMBER));
+        FunctionMetaData functionMetaData2 = new org.eclipse.daanse.olap.function.core.FunctionMetaDataR(functionAtom2,
+                "functionMetaData2Description", DataType.MEMBER,
+                new org.eclipse.daanse.olap.function.core.FunctionParameterR[] {
+                        org.eclipse.daanse.olap.function.core.FunctionParameterR.param(DataType.CUBE) });
 
         when(functionService.getFunctionMetaDatas())
                 .thenAnswer(setupDummyListAnswer(functionMetaData1, functionMetaData2));
 
         when(request.restrictions()).thenReturn(restrictions);
+        when(request.properties()).thenReturn(properties);
+        when(properties.localeIdentifier()).thenReturn(Optional.empty());
+        when(restrictions.functionName()).thenReturn(Optional.empty());
+        when(restrictions.origin()).thenReturn(Optional.empty());
+        when(restrictions.interfaceName()).thenReturn(Optional.empty());
+        when(restrictions.libraryName()).thenReturn(Optional.empty());
         when(context1.getFunctionService()).thenReturn(functionService);
         List<MdSchemaFunctionsResponseRow> rows = service.mdSchemaFunctions(request, requestMetaData);
         assertThat(rows).isNotNull().hasSize(2);
         checkMdSchemaFunctionsResponseRow(rows.get(0), "functionAtom1Name", "functionMetaData1Description",
-                "Integer, Member", 2, OriginEnum.MSOLAP, "functionAtom1Name");
-        checkMdSchemaFunctionsResponseRow(rows.get(1), "functionAtom2Name", "functionMetaData2Description", "Cube", 12,
-                OriginEnum.MSOLAP, "functionAtom2Name");
-
+                "«Index», «Member»", 3, OriginEnum.MSOLAP, "functionAtom1Name");
+        checkMdSchemaFunctionsResponseRow(rows.get(1), "functionAtom2Name", "functionMetaData2Description", "«Cube»",
+                12, OriginEnum.MSOLAP, "functionAtom2Name");
+        assertThat(rows.get(0).parameterInfo()).isPresent();
+        assertThat(rows.get(0).parameterInfo().get()).hasSize(2);
+        // method syntax exposes the calling object type
+        assertThat(rows.get(1).object()).contains("Cube");
     }
 
     @Test

--- a/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/MdSchemaFunctionsRowMapperTest.java
+++ b/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/MdSchemaFunctionsRowMapperTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.olap.xmla.bridge.discover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
+import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionMetaData;
+import org.eclipse.daanse.olap.api.function.FunctionService;
+import org.eclipse.daanse.olap.api.function.FunctionTextProvider;
+import org.eclipse.daanse.olap.api.function.FunctionTexts;
+import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
+import org.eclipse.daanse.olap.function.core.FunctionParameterR;
+import org.eclipse.daanse.olap.function.core.text.FunctionTextServiceImpl;
+import org.eclipse.daanse.xmla.api.common.enums.InterfaceNameEnum;
+import org.eclipse.daanse.xmla.api.common.enums.OriginEnum;
+import org.eclipse.daanse.xmla.api.discover.mdschema.functions.MdSchemaFunctionsResponseRow;
+import org.eclipse.daanse.xmla.api.discover.mdschema.functions.MdSchemaFunctionsRestrictions;
+import org.eclipse.daanse.xmla.api.discover.mdschema.functions.ParameterInfo;
+import org.junit.jupiter.api.Test;
+
+class MdSchemaFunctionsRowMapperTest {
+
+    private static FunctionMetaData sumMetaData() {
+        return FunctionMetaDataR.of(new FunctionOperationAtom("Sum"),
+                "Returns the sum of a numeric expression evaluated over a set.", DataType.NUMERIC,
+                FunctionParameterR.param(DataType.SET),
+                FunctionParameterR.param(DataType.NUMERIC).asOptional()
+                        .describedAs("Expression evaluated per member."));
+    }
+
+    private static FunctionService serviceWith(FunctionMetaData... fmds) {
+        FunctionService service = mock(FunctionService.class);
+        when(service.getFunctionMetaDatas()).thenReturn(List.of(fmds));
+        return service;
+    }
+
+    private static MdSchemaFunctionsRestrictions noRestrictions() {
+        MdSchemaFunctionsRestrictions restrictions = mock(MdSchemaFunctionsRestrictions.class);
+        when(restrictions.functionName()).thenReturn(Optional.empty());
+        when(restrictions.origin()).thenReturn(Optional.empty());
+        when(restrictions.interfaceName()).thenReturn(Optional.empty());
+        when(restrictions.libraryName()).thenReturn(Optional.empty());
+        return restrictions;
+    }
+
+    @Test
+    void emitsFullRowWithParameterInfo() {
+        List<MdSchemaFunctionsResponseRow> rows = MdSchemaFunctionsRowMapper.rows(serviceWith(sumMetaData()),
+                new FunctionTextServiceImpl(), Locale.ENGLISH, noRestrictions());
+
+        assertThat(rows).hasSize(1);
+        MdSchemaFunctionsResponseRow row = rows.get(0);
+        assertThat(row.functionName()).contains("Sum");
+        assertThat(row.parameterList()).isEqualTo("«Set», [«Numeric Expression»]");
+        assertThat(row.returnType()).contains(5); // DBTYPE_R8
+        assertThat(row.origin()).contains(OriginEnum.MSOLAP);
+        assertThat(row.interfaceName()).contains(InterfaceNameEnum.NUMERIC);
+        assertThat(row.caption()).contains("Sum");
+
+        assertThat(row.parameterInfo()).isPresent();
+        List<ParameterInfo> parameterInfos = row.parameterInfo().get();
+        assertThat(parameterInfos).hasSize(2);
+        assertThat(parameterInfos.get(0).name()).isEqualTo("Set");
+        assertThat(parameterInfos.get(0).optional()).isFalse();
+        assertThat(parameterInfos.get(1).name()).isEqualTo("Numeric Expression");
+        assertThat(parameterInfos.get(1).optional()).isTrue();
+        assertThat(parameterInfos.get(1).description()).isEqualTo("Expression evaluated per member.");
+    }
+
+    @Test
+    void appliesFunctionNameRestriction() {
+        MdSchemaFunctionsRestrictions restrictions = noRestrictions();
+        when(restrictions.functionName()).thenReturn(Optional.of("other"));
+
+        List<MdSchemaFunctionsResponseRow> rows = MdSchemaFunctionsRowMapper.rows(serviceWith(sumMetaData()),
+                new FunctionTextServiceImpl(), Locale.ENGLISH, restrictions);
+
+        assertThat(rows).isEmpty();
+    }
+
+    @Test
+    void appliesInterfaceNameRestriction() {
+        MdSchemaFunctionsRestrictions restrictions = noRestrictions();
+        when(restrictions.interfaceName()).thenReturn(Optional.of(InterfaceNameEnum.NUMERIC));
+
+        List<MdSchemaFunctionsResponseRow> rows = MdSchemaFunctionsRowMapper.rows(serviceWith(sumMetaData()),
+                new FunctionTextServiceImpl(), Locale.ENGLISH, restrictions);
+
+        assertThat(rows).hasSize(1);
+    }
+
+    @Test
+    void localizesDescriptionAndCaption() {
+        FunctionTextServiceImpl textService = new FunctionTextServiceImpl();
+        textService.addProvider(germanProvider());
+
+        List<MdSchemaFunctionsResponseRow> rows = MdSchemaFunctionsRowMapper.rows(serviceWith(sumMetaData()),
+                textService, Locale.of("de", "DE"), noRestrictions());
+
+        MdSchemaFunctionsResponseRow row = rows.get(0);
+        assertThat(row.description()).hasValueSatisfying(
+                v -> assertThat(v).contains("Summe eines numerischen Ausdrucks"));
+        assertThat(row.caption()).contains("Summe");
+        // technical identity stays invariant
+        assertThat(row.functionName()).contains("Sum");
+    }
+
+    @Test
+    void mapsLcidToLocale() {
+        assertThat(MdSchemaFunctionsRowMapper.localeOf(Optional.of(1031)).getLanguage()).isEqualTo("de");
+        assertThat(MdSchemaFunctionsRowMapper.localeOf(Optional.empty())).isEqualTo(Locale.ENGLISH);
+        assertThat(MdSchemaFunctionsRowMapper.localeOf(Optional.of(99999))).isEqualTo(Locale.ENGLISH);
+    }
+
+    @Test
+    void mapsReturnTypesToOleDb() {
+        assertThat(MdSchemaFunctionsRowMapper.oleDbTypeOf(DataType.INTEGER)).isEqualTo(3);
+        assertThat(MdSchemaFunctionsRowMapper.oleDbTypeOf(DataType.LOGICAL)).isEqualTo(11);
+        assertThat(MdSchemaFunctionsRowMapper.oleDbTypeOf(DataType.STRING)).isEqualTo(130);
+        assertThat(MdSchemaFunctionsRowMapper.oleDbTypeOf(DataType.SET)).isEqualTo(12);
+        assertThat(MdSchemaFunctionsRowMapper.oleDbTypeOf(DataType.DATE_TIME)).isEqualTo(7);
+    }
+
+    private static FunctionTextProvider germanProvider() {
+        return (key, locale) -> {
+            if (!"de".equals(locale.getLanguage()) || !"Sum".equals(key)) {
+                return Optional.empty();
+            }
+            return Optional.of(new FunctionTexts(
+                    Optional.of("Liefert die Summe eines numerischen Ausdrucks über eine Menge."),
+                    Optional.of("Summe"), Optional.empty(), Optional.empty(), Map.of()));
+        };
+    }
+}


### PR DESCRIPTION
The function API could not describe what a function actually accepts:
parameters were largely unnamed, optionality was modelled as separate
arity overloads, and the XMLA discover had almost nothing to report.
This reworks the metadata, the resolution path and the MDSCHEMA_FUNCTIONS
rowset.

API (breaking):
- FunctionParameter gains optional/repeatable/repeatGroup/skippable and
  mandatory names taken from a canonical vocabulary; param() factories
  and withers replace the positional constructors.
- FunctionMetaData carries caption, origin, functionInterface, textKey,
  callingObject and min/maxArity, and holds its parameters as a List, so
  equality is structural again instead of array identity.
- FunctionResolver.resolve returns Optional<FunctionResolutionResult>
  carrying the matched metadata, the argument bindings and the applied
  conversions, replacing the out-parameter list.
- New enums FunctionInterface and FunctionOrigin, plus an i18n SPI
  (FunctionTextProvider, FunctionTextService) with per-language bundles;
  names stay invariant, descriptions and captions are localized.

Resolution:
- FunctionMetaDataMatcher walks the declared parameters positionally
  with skip semantics and repeat groups, so Order, Case, CrossJoin and
  the tuple forms are described declaratively instead of by hand.
- 62 arity-only multi-resolvers collapse onto a single metadata with
  optional parameters; genuine type overloads stay separate.
- ValidatorImpl.explainDef reports the candidates and why they were
  rejected; the user-facing error messages are unchanged.

XMLA discover:
- MdSchemaFunctionsRowMapper fills PARAMETERINFO, PARAMETER_LIST in
  chevron style, INTERFACE_NAME, ORIGIN, LIBRARY_NAME, OBJECT and
  CAPTION, honours the restrictions and no longer repeats the function
  list per catalog. RETURN_TYPE now reports OLE-DB DBTYPE codes instead
  of VarType ordinals - the one client-visible change.

Bugs found along the way: FunctionServiceImpl.removeResolver added
instead of removed; the createFunDef hook was bypassed, which broke the
per-call state NativizeSet depends on; HideMemberCondition.fromValue
never matched the mapping literals and silently disabled every ragged
hierarchy; FunUtil.checkNativeCompatible read args[0] on zero-argument
calls.

Signed-off-by: Stefan Bischof <stbischof@bipolis.org>